### PR TITLE
Fix the display of the leaderboard for user having no badges

### DIFF
--- a/tahrir/templates/leaderboard.mak
+++ b/tahrir/templates/leaderboard.mak
@@ -15,13 +15,18 @@
               You are ranked <strong>#${rank}</strong> out of ${user_count} ranked users.
             </p>
             <p>You are in the <strong>top ${"{0:.1f}".format(percentile)}%</strong>.</p>
+          % endif
             <h3>Competitors</h3>
             <table>
               % for person in competitors:
                 % if person.email == logged_in:
                   <tr>
                     <td>
+                    % if person.rank:
                       <span class="big-text"><strong>#${person.rank}</strong></span>
+                    % else:
+                      <span class="big-text"><strong>-</strong></span>
+                    % endif
                     </td>
                     <td>${self.functions.avatar_thumbnail(person, 64, 33)}</td>
                     <td>
@@ -31,7 +36,11 @@
                     </td>
                   % else:
                     <td>
+                    % if person.rank:
                       <span class="big-text">#${person.rank}</span>
+                    % else:
+                      <span class="big-text">-</span>
+                    % endif
                     </td>
                     <td>${self.functions.avatar_thumbnail(person, 64, 33)}</td>
                     <td><a href="${request.route_url('user', id=person.nickname or person.id)}">${person.nickname}</a></td>
@@ -39,7 +48,6 @@
                 </tr>
               % endfor
             </table>
-          % endif
         % else:
           <p>Log in to see your rank. There are ${user_count} ranked users.</p>
         % endif

--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -268,16 +268,22 @@ def leaderboard(request):
         user = request.db.get_person(
             person_email=authenticated_userid(request))
 
-    leaderboard = request.db.session\
-        .query(m.Person)\
-        .order_by(m.Person.rank)\
-        .filter(m.Person.opt_out == False)\
-        .all()
+    query = request.db.session.query(
+        m.Person
+    ).order_by(
+        m.Person.rank,
+        m.Person.created_on,
+    ).filter(
+        m.Person.opt_out == False
+    )
+
+    leaderboard = query.filter(m.Person.rank != None).all()
+    # Get total user count.
+    user_count = len(leaderboard)
+    leaderboard.extend(query.filter(m.Person.rank == None).all())
 
     user_to_rank = request.db._make_leaderboard()
 
-    # Get total user count.
-    user_count = len(leaderboard)
 
     if user:
         awarded_assertions = user.assertions


### PR DESCRIPTION
For user with no badges, ie no rank, we need to retrieve the list of users
with badges and extend this list with the user without badges but then
ordered by the date of creation.
This allows user with no rank to still see themselves in the leaderboard.

Fixes: https://github.com/fedora-infra/tahrir/issues/135
