### PR TITLE
Make site logo set via stylesheet. For #64, probably closing it.

### DIFF
--- a/tahrir/static/css/tahrir.css
+++ b/tahrir/static/css/tahrir.css
@@ -35,6 +35,15 @@ legend {
     text-decoration: none;
 }
 
+#site-logo {
+    width: 600px;
+    height: 200px;
+    background-image: url(../img/fedora_badges_small.png);
+    background-repeat: no-repeat;
+    margin-right: 10px;
+    margin-left: 10px;
+    margin-top: 10px;
+}
 
 /* Applied to numbering, mainly (ex. #1, #2, etc.). */
 .big-text {
@@ -133,12 +142,6 @@ td {
 tr:nth-child(odd) { background: #E8EFF8; } /* "Clear day" */
 
 tr:nth-child(even) { background: white; }
-
-.logo-image {
-    margin-right: 10px;
-    margin-left: 10px;
-    margin-top: 10px;
-}
 
 #logo {
     color: #9B9B9B; /* Dark gray */

--- a/tahrir/templates/master.mak
+++ b/tahrir/templates/master.mak
@@ -53,10 +53,8 @@
         <div class="header clearfix grid-100">
           <h1>
             <a href="${request.route_url('home')}">
-              <img
-                 src="${request.static_url('%s:static/img/fedora_badges_small.png' % theme_name)}"
-                 alt="Fedora Badges logo"
-                 class="logo-image"/>
+            <div id="site-logo">
+            </div>
             </a>
           </h1>
         </div>


### PR DESCRIPTION
As per the comment on issue #64:

"Alright! So, I have the fix for this. I have decided (and I think folks will agree) that it would be best to just use the already-implemented custom CSS option to full effect. The changes I am about to push make the site logo set in the CSS file. That means that now, everything is themable via the CSS, and so this ticket is closable. This doesn't mean that in the future, we can't make theming possible without CSS, but for now I think this is more than enough and doubt that many people will be deploying Tahrir who don't have CSS abilities.

I'll wait for a +1 before merging in. :dancer:"
