### PR TITLE
Make the theme really configurable.

### DIFF
--- a/development.ini.example
+++ b/development.ini.example
@@ -61,7 +61,9 @@ tahrir.websocket.topic = org.fedoraproject.stg.fedbadges.badge.award
 tahrir.use_openid_email = False
 
 # You can optionally create your own CSS theme for tahrir
-# tahrir.static.uri = /home/user/tahrir-theme
+# Specify a python module name that contains static/{css,js,img} dirs.
+# By default, tahrir's own static/ folder contents are used.
+#tahrir.theme_name = tahrir
 
 tahrir.use_websockets = True
 

--- a/tahrir/__init__.py
+++ b/tahrir/__init__.py
@@ -123,7 +123,7 @@ def main(global_config, **settings):
 
     config.add_static_view(
         'static',
-        settings.get('tahrir.static.uri', 'static'),
+        settings.get('tahrir.theme_name', 'tahrir') + ':static',
         cache_max_age=3600,
     )
     config.add_static_view(

--- a/tahrir/events.py
+++ b/tahrir/events.py
@@ -32,6 +32,7 @@ def inject_globals(event):
     # dict returned by the view every time!
     event['title'] = settings['tahrir.title']
     event['base_url'] = settings['tahrir.base_url']
+    event['theme_name'] = settings.get('tahrir.theme_name', 'tahrir')
 
     event['tahrir_version'] = get_distribution('tahrir').version
     event['tahrir_api_version'] = get_distribution('tahrir-api').version

--- a/tahrir/templates/404.mak
+++ b/tahrir/templates/404.mak
@@ -2,15 +2,15 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <link rel="stylesheet" href="${request.static_url('tahrir:static/css/tahrir.css')}">
-    <link rel="stylesheet" href="${request.static_url('tahrir:static/css/monokai.css')}">
+    <link rel="stylesheet" href="${request.static_url('%s:static/css/tahrir.css' % theme_name)}">
+    <link rel="stylesheet" href="${request.static_url('%s:static/css/monokai.css' % theme_name)}">
     <title>404</title>
   </head>
   <body>
     <div class="page">
       <div class="center pane">
         <img
-           src="${request.static_url('tahrir:static/img/404.png')}"
+           src="${request.static_url('%s:static/img/404.png' % theme_name)}"
            alt="Achievment Unlocked, 'Failure'"
            style="display: block; margin-left: auto; margin-right: auto;" />
       </div>

--- a/tahrir/templates/500.mak
+++ b/tahrir/templates/500.mak
@@ -2,15 +2,15 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <link rel="stylesheet" href="${request.static_url('tahrir:static/css/tahrir.css')}">
-    <link rel="stylesheet" href="${request.static_url('tahrir:static/css/monokai.css')}">
+    <link rel="stylesheet" href="${request.static_url('%s:static/css/tahrir.css' % theme_name)}">
+    <link rel="stylesheet" href="${request.static_url('%s:static/css/monokai.css' % theme_name)}">
     <title>500 Error</title>
   </head>
   <body>
     <div class="page">
       <div class="center pane">
         <img
-           src="${request.static_url('tahrir:static/img/500.png')}"
+           src="${request.static_url('%s:static/img/500.png' % theme_name)}"
            alt="Achievment Unlocked, 'Failure'"
            style="display: block; margin-left: auto; margin-right: auto;" />
       </div>

--- a/tahrir/templates/builder.mak
+++ b/tahrir/templates/builder.mak
@@ -1,5 +1,5 @@
 <%inherit file="master.mak"/>
-<script type="text/javascript" src="${request.static_url('tahrir:static/js/builder.js')}"></script>
+<script type="text/javascript" src="${request.static_url('%s:static/js/builder.js' % theme_name)}"></script>
 <div class="page">
   <div class="grid-100">
     <h1 class="section-header">Badge Builder</h1>

--- a/tahrir/templates/master.mak
+++ b/tahrir/templates/master.mak
@@ -7,12 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1,
                                    maximum-scale=1" />
     <!-- end viewport stuff -->
-    <link rel="stylesheet" href="${request.static_url('tahrir:static/css/tahrir.css')}" />
-    <link rel="stylesheet" href="${request.static_url('tahrir:static/css/monokai.css')}" />
-    <link rel="stylesheet" media="mobile" href="${request.static_url('tahrir:static/css/unsemantic-grid-mobile.css')}" />
-    <link rel="stylesheet" media="screen" href="${request.static_url('tahrir:static/css/unsemantic-grid-responsive.css')}" />
-    <link rel="shortcut icon" href="${request.static_url('tahrir:static/img/favicon.ico')}" />
-    <script src="${request.static_url('tahrir:static/js/social.js')}"></script>
+    <link rel="stylesheet" href="${request.static_url('%s:static/css/tahrir.css' % theme_name)}" />
+    <link rel="stylesheet" href="${request.static_url('%s:static/css/monokai.css' % theme_name)}" />
+    <link rel="stylesheet" media="mobile" href="${request.static_url('%s:static/css/unsemantic-grid-mobile.css' % theme_name)}" />
+    <link rel="stylesheet" media="screen" href="${request.static_url('%s:static/css/unsemantic-grid-responsive.css' % theme_name)}" />
+    <link rel="shortcut icon" href="${request.static_url('%s:static/img/favicon.ico' % theme_name)}" />
+    <script src="${request.static_url('%s:static/js/social.js' % theme_name)}"></script>
     % if logged_in and awarded_assertions:
       <script src="//beta.openbadges.org/issuer.js"></script>
       <script>
@@ -54,7 +54,7 @@
           <h1>
             <a href="${request.route_url('home')}">
               <img
-                 src="${request.static_url('tahrir:static/img/fedora_badges_small.png')}"
+                 src="${request.static_url('%s:static/img/fedora_badges_small.png' % theme_name)}"
                  alt="Fedora Badges logo"
                  class="logo-image"/>
             </a>

--- a/tahrir/utils.py
+++ b/tahrir/utils.py
@@ -90,8 +90,9 @@ def make_avatar_method(cache):
     @cache.cache_on_arguments()
     def _avatar_function(email, size):
         request = pyramid.threadlocal.get_current_request()
+        theme_name = request.registry.settings.get('tahrir.theme_name', 'tahrir')
         absolute_default = request.static_url(
-            'tahrir:static/img/badger_avatar.png')
+            '%s:static/img/badger_avatar.png' % theme_name)
 
         query = {
             's': size,


### PR DESCRIPTION
We wrote this in in the beginning but never really tested it thoroughly.

It turns out that Pyramid "Asset Specifications" didn't quite work the
way we thought they did.  They aren't relative to the pyramid
application but to python module names.  The changes here make it so
that we can create themes (say, the "fossrit_tahrir_theme" and the
"threebean_tahrir_theme") and distribute them on pypi.  Enabling them is
as simple now as listing their module name in the development.ini.
