### PR TITLE
Fix TypeError that occured when viewing a user page when badges have not been awarded.

### DIFF
--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -779,7 +779,7 @@ def user(request):
                    if i.expires_on > datetime.now()]
 
     # Get rank. (same code found in leaderboard view function)
-    rank = user.rank
+    rank = user.rank or 0
     user_count = request.db.session.query(m.Person)\
         .filter(m.Person.opt_out == False).count()
 


### PR DESCRIPTION
When viewing a profile page when badges have not been awarded, the system throws `TypeError: float() argument must be a string or a number` on the line `percentile = (float(rank) / float(user_count)) * 100`.

This change should prevent that from happening.
