### PR TITLE
Make add invitation accept the creator as email address instead of person ID.

### DIFF
--- a/tahrir/templates/admin.mak
+++ b/tahrir/templates/admin.mak
@@ -108,8 +108,12 @@
           <td><input name="badge-criteria" required="required" placeholder="oursite.tld/mailinglist/awesome_badge_discussion"/></td>
         </tr>
         <tr>
-          <td><label for="badge-issuer">Issuer ID</label></td>
-          <td><input name="badge-issuer" required="required" placeholder="1"/></td>
+          <td><label for="badge-issuer">Issuer</label></td>
+		  <td><select name="badge-issuer">
+		  % for issuer in issuers:
+			<option value="${issuer.id}">${issuer.name} (${issuer.id})</option>
+		  % endfor
+		  </select></td>
         </tr>
         <tr>
           <td><label for="badge-tags">Tags <span class="sublabel">Comma-delimited list of tags.</span></label></td>

--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -212,6 +212,7 @@ def admin(request):
     return dict(
         auth_principals=effective_principals(request),
         awarded_assertions=awarded_assertions,
+        issuers=request.db.get_all_issuers().all(),
     )
 
 


### PR DESCRIPTION
Requires fedora-infra/tahrir-api#30
