### PR TITLE
Allow admin to set default avatar explicitly.

### DIFF
--- a/tahrir/utils.py
+++ b/tahrir/utils.py
@@ -90,9 +90,9 @@ def make_avatar_method(cache):
     @cache.cache_on_arguments()
     def _avatar_function(email, size):
         request = pyramid.threadlocal.get_current_request()
-        theme_name = request.registry.settings.get('tahrir.theme_name', 'tahrir')
-        absolute_default = request.static_url(
-            '%s:static/img/badger_avatar.png' % theme_name)
+        absolute_default = request.registry.settings.get(
+            'tahrir.default_avatar',
+            'https://badges.fedoraproject.org/static/img/badger_avatar.png')
 
         query = {
             's': size,


### PR DESCRIPTION
This is to get around a heisenbug we're seing in production, where
_sometimes_ the request.static_url returns the url of badges.fp.o, and
_other_ times it returns localhost.  Very frustrating.

If we just let the admin hardcode it, everything will be easier.
