### PR TITLE
Remove image that does not exist and breaks https

### DIFF
--- a/fedora-sitedocs/about.rst
+++ b/fedora-sitedocs/about.rst
@@ -3,9 +3,6 @@ Fedora Badges
 
 `Fedora Badges <https://badges.fedoraproject.org>`_ is a fun website built to recognize contributors to the `Fedora Project <https://fedoraproject.org>`_, help new and existing Fedora contributors find different ways to get involved, and encourage the improvement of Fedora's infrastructure.
 
-.. image:: http://oddshocks.com/presentations/fedora_badges/badges_fan.png
-   :alt: Fedora Badges
-
 How does Badges work?
 ---------------------
 


### PR DESCRIPTION
I noticed on the About page that there is some Alt text displayed near the beginning. Turns out the link to this image doesn't exist.

Also, since this is an external image, Firefox warns that the page is insecure due to unencrypted elements.
