### PR TITLE
Make the history pane less unwieldy.

### DIFF
--- a/tahrir/static/css/tahrir.css
+++ b/tahrir/static/css/tahrir.css
@@ -408,3 +408,9 @@ footer > .document {
 .name > small {
     color: #888888;
 }
+
+@media all and (max-width:  768px) {
+    .mobile-hidden {
+        display: none !important;
+    }
+}

--- a/tahrir/templates/user.mak
+++ b/tahrir/templates/user.mak
@@ -152,7 +152,7 @@
       <h1 class="section-header">History</h1>
       <div class="padded-content clearfix">
         <div class="grid-container">
-          % for assertion in sorted(user.assertions, key=lambda a: a.issued_on, reverse=True):
+          % for assertion in sorted(user.assertions, key=lambda a: a.issued_on, reverse=True)[:history_limit]:
             ${self.functions.badge_thumbnail(assertion.badge, 64, 33)}
             <div class="grid-66 text-64"><p>received on ${assertion.issued_on.strftime('%Y-%m-%d')}
               % if assertion.issued_for:
@@ -160,6 +160,13 @@
               % endif
               </p></div>
           % endfor
+          % if history_limit < len(user.assertions):
+          <div class="grid-66 text-64"><p>
+            This is only the last ${history_limit} entries.
+            <a href="${request.route_url('user', id=user.nickname or user.id, _query=dict(history_limit=len(user.assertions)))}">
+              Click here to see all of them</a>.
+          </p></div>
+          % endif
         </div>
       </div> <!-- End padded content. -->
     </div> <!-- End shadow. -->

--- a/tahrir/templates/user.mak
+++ b/tahrir/templates/user.mak
@@ -148,7 +148,7 @@
     </div> <!-- End shadow. -->
 
     % if user.assertions:
-    <div class="shadow">
+    <div class="shadow mobile-hidden">
       <h1 class="section-header">History</h1>
       <div class="padded-content clearfix">
         <div class="grid-container">

--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -909,6 +909,8 @@ def user(request):
     user_id = request.matchdict.get('id')
     user = _get_user(request, user_id)
 
+    history_limit = int(request.params.get('history_limit', 10))
+
     if not user:
         raise HTTPNotFound("No such user %r" % user_id)
 
@@ -969,6 +971,7 @@ def user(request):
             rank=rank,
             percentile=percentile,
             user_count=user_count,
+            history_limit=history_limit,
             )
 
 


### PR DESCRIPTION
3a34180 - Completely hide the history pane in the mobile view.
acb60ba - Shorten the number of entries in the user-history pane.

Fixes #295.