### PR TITLE
Lay out badges according to their tags.

### DIFF
--- a/development.ini.example
+++ b/development.ini.example
@@ -45,6 +45,7 @@ tahrir.allow_changenick = True
 tahrir.use_fedmsg = True
 tahrir.default_issuer = fedora-project
 tahrir.openbadges_modal = True
+tahrir.display_tags = account,event
 
 tahrir.sitedocs_dir = %(here)s/fedora-sitedocs
 

--- a/tahrir/templates/explore_badges.mak
+++ b/tahrir/templates/explore_badges.mak
@@ -12,7 +12,7 @@
         % if tag in sum([badge.tags.strip(",").split(",") for badge in all_badges], []):
         <h3 class="section-header">${tag.title()} Badges</h3>
         <div class="flex-container">
-          % for badge in [b  for b in all_badges if tag in b.tags]:
+          % for badge in [b for b in all_badges if tag in b.tags.strip(",").split(",")]:
             ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
           % endfor
         </div>
@@ -21,7 +21,7 @@
         % if any([badge for badge in all_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in badge.tags.strip(",").split(",")])]):
         <h3 class="section-header">Uncategorized Badges</h3>
         <div class="flex-container">
-          % for badge in [b  for b in all_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
+          % for badge in [b for b in all_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
             ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
           % endfor
         </div>
@@ -38,7 +38,7 @@
         % if tag in sum([badge.tags.strip(",").split(",") for badge in newest_badges], []):
         <h3 class="section-header">${tag.title()} Badges</h3>
         <div class="flex-container">
-          % for badge in [b  for b in newest_badges if tag in b.tags]:
+          % for badge in [b for b in newest_badges if tag in b.tags.strip(",").split(",")]:
             ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
           % endfor
         </div>
@@ -47,7 +47,7 @@
         % if any([badge for badge in newest_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in badge.tags.strip(",").split(",")])]):
         <h3 class="section-header">Uncategorized Badges</h3>
         <div class="flex-container">
-          % for badge in [b  for b in newest_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
+          % for badge in [b for b in newest_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
             ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
           % endfor
         </div>

--- a/tahrir/templates/explore_badges.mak
+++ b/tahrir/templates/explore_badges.mak
@@ -7,10 +7,25 @@
   <div class="grid-50">
     <div class="shadow">
       <h1 class="section-header">All Badges</h1>
-      <div class="flex-container padded-content">
-        % for badge in all_badges:
-          ${self.functions.badge_thumbnail_flex(badge, 64, 15)}
+      <div class="padded-content">
+        % for tag in request.registry.settings.get('tahrir.display_tags', '').split(","):
+        % if tag in sum([badge.tags.strip(",").split(",") for badge in all_badges], []):
+        <h3 class="section-header">${tag.title()} Badges</h3>
+        <div class="flex-container">
+          % for badge in [b  for b in all_badges if tag in b.tags]:
+            ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
+          % endfor
+        </div>
+        % endif
         % endfor
+        % if any([badge for badge in all_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in badge.tags.strip(",").split(",")])]):
+        <h3 class="section-header">Uncategorized Badges</h3>
+        <div class="flex-container">
+          % for badge in [b  for b in all_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
+            ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
+          % endfor
+        </div>
+        % endif
       </div> <!-- End padded content. -->
     </div> <!-- End shadow. -->
   </div>
@@ -18,10 +33,25 @@
   <div class="grid-50">
     <div class="shadow">
       <h1 class="section-header">Newest Badges</h1>
-      <div class="flex-container padded-content">
-        % for badge in newest_badges:
-          ${self.functions.badge_thumbnail_flex(badge, 64, 15)}
+      <div class="padded-content">
+        % for tag in request.registry.settings.get('tahrir.display_tags', '').split(","):
+        % if tag in sum([badge.tags.strip(",").split(",") for badge in newest_badges], []):
+        <h3 class="section-header">${tag.title()} Badges</h3>
+        <div class="flex-container">
+          % for badge in [b  for b in newest_badges if tag in b.tags]:
+            ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
+          % endfor
+        </div>
+        % endif
         % endfor
+        % if any([badge for badge in newest_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in badge.tags.strip(",").split(",")])]):
+        <h3 class="section-header">Uncategorized Badges</h3>
+        <div class="flex-container">
+          % for badge in [b  for b in newest_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
+            ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
+          % endfor
+        </div>
+        % endif
       </div> <!-- End padded content -->
     </div> <!-- End shadow. -->
   </div> <!-- End grid-50 -->

--- a/tahrir/templates/user.mak
+++ b/tahrir/templates/user.mak
@@ -208,7 +208,7 @@
         % if tag in sum([badge.tags.strip(",").split(",") for badge in user_badges], []):
         <h3 class="section-header">${tag.title()} Badges</h3>
         <div class="flex-container">
-          % for badge in [b  for b in user_badges if tag in b.tags]:
+          % for badge in [b for b in user_badges if tag in b.tags.strip(",").split(",")]:
             ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
           % endfor
         </div>
@@ -217,7 +217,7 @@
         % if any([badge for badge in user_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in badge.tags.strip(",").split(",")])]):
         <h3 class="section-header">Uncategorized Badges</h3>
         <div class="flex-container">
-          % for badge in [b  for b in user_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
+          % for badge in [b for b in user_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
             ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
           % endfor
         </div>

--- a/tahrir/templates/user.mak
+++ b/tahrir/templates/user.mak
@@ -204,11 +204,24 @@
             (<strong>${"{0:.1f}".format(percent_earned)}%</strong> of total).
           % endif
         </div>
+        % for tag in request.registry.settings.get('tahrir.display_tags', '').split(","):
+        % if tag in sum([badge.tags.strip(",").split(",") for badge in user_badges], []):
+        <h3 class="section-header">${tag.title()} Badges</h3>
         <div class="flex-container">
-          % for i, badge in enumerate(user_badges):
+          % for badge in [b  for b in user_badges if tag in b.tags]:
             ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
           % endfor
         </div>
+        % endif
+        % endfor
+        % if any([badge for badge in user_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in badge.tags.strip(",").split(",")])]):
+        <h3 class="section-header">Uncategorized Badges</h3>
+        <div class="flex-container">
+          % for badge in [b  for b in user_badges if not any([tag in request.registry.settings.get('tahrir.display_tags', '').split(",") for tag in b.tags.strip(",").split(",")])]:
+            ${self.functions.badge_thumbnail_flex(badge, 128, 33)}
+          % endfor
+        </div>
+        % endif
       </div>
     </div> <!-- End padded content. -->
   </div> <!-- End shadow. -->


### PR DESCRIPTION
This relates to #122 and we might even say it fixes it.  It should make the
default view readable enough that we don't need all kinds of custom sorting
(which would be non-trivial to implement).