### PR TITLE
Allow users to specify a limit to the json leaderboard.

### DIFF
--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -460,6 +460,7 @@ def leaderboard(request):
 def leaderboard_json(request):
     """ Render a top-users JSON dump. """
 
+    limit = int(request.params.get('limit', 25))
     user_id = request.matchdict.get('id')
     user = None
     if user_id:
@@ -491,7 +492,7 @@ def leaderboard_json(request):
 
         leaderboard = leaderboard[(idx - 2):(idx + 3)]
     else:
-        leaderboard = leaderboard[:25]
+        leaderboard = leaderboard[:limit]
 
     ret = [
         dict(user_to_rank[p].items() + [('nickname', p.nickname)])


### PR DESCRIPTION
With this, you could then set limit=1000000 to get a json response
containing all users in the db if you wanted to, say, do analytics on
Fedora Badges for a school project.