### PR TITLE
Changes for RPM-based distributions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ https://admin.fedoraproject.org/accounts. Make sure you have Python 2.7 or
 above installed on your system. Then, install the Python version of
 virtualenvwrapper (in Fedora)::
 
-	$ sudo yum -y install python-virtualenvwrapper
+	$ sudo dnf -y install python-virtualenvwrapper
 
 In Ubuntu, you can do the same with::
 
@@ -107,9 +107,9 @@ first time::
 
     $ export WORKON_HOME=~/.virtualenvs/
     $ mkdir -p $WORKON_HOME
-    $ source /usr/local/bin/virtualenvwrapper.sh
+    $ source /usr/bin/virtualenvwrapper.sh
 
-You'll want to add ``source /usr/local/bin/virtualenvwrapper.sh`` to
+You'll want to add ``source /usr/bin/virtualenvwrapper.sh`` to
 your ``.bashrc``.
 
 Then, to set up Tahrir, follow these steps::
@@ -118,8 +118,8 @@ Then, to set up Tahrir, follow these steps::
 	$ cd tahrir
 	$ mkvirtualenv tahrir
 	(tahrir)$ python setup.py develop
-	(tahrir)$ cp development.ini.sample development.ini
-	(tahrir)$ cp secret.ini.sample secret.ini
+	(tahrir)$ cp development.ini.example development.ini
+	(tahrir)$ cp secret.ini.example secret.ini
 	(tahrir)$ initialize_tahrir_db development.ini
 	(tahrir)$ pserve --reload development.ini
 


### PR DESCRIPTION
For RPM-based distributions it should be /usr/bin/virtualwrapper.sh
Since there is no such file named as development.ini.sample it can be changed to development.ini.example, same for secret.ini.sample