### PR TITLE
fix the percentile for the top users in the leaderboard

### DIFF
--- a/tahrir/templates/user.mak
+++ b/tahrir/templates/user.mak
@@ -31,7 +31,7 @@
 
           % if rank != 0:
             <p>
-              Ranked ${rank} out of ${user_count} ranked users (top ${"{0:.1f}".format(percentile)}%).</p>
+              Ranked ${rank} out of ${user_count} ranked users (top ${"{0:.2f}".format(percentile)}%).</p>
           % else:
             <p>Not ranked yet.</p>
           % endif

--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -14,6 +14,7 @@ import markupsafe
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from decimal import Decimal, ROUND_UP
 
 from mako.template import Template as t
 from webhelpers import feedgenerator
@@ -999,7 +1000,8 @@ def user(request):
         .filter(m.Person.opt_out == False).count()
 
     try:
-        percentile = (float(rank) / float(user_count)) * 100
+        percentile = Decimal(float(rank) / float(user_count)).quantize(
+            Decimal('.01'), rounding=ROUND_UP)
     except ZeroDivisionError:
         percentile = 0
 


### PR DESCRIPTION
Currently the top users in the leaderboard see (top 0.0%) instead it should be something like (top 0.01%)