### PR TITLE
Change "add assertion" to "award individual badge"

### DIFF
--- a/tahrir/templates/admin.mak
+++ b/tahrir/templates/admin.mak
@@ -226,7 +226,7 @@
         </tr>
         <tr>
           <td></td><td>
-            <input name="add-assertion" type="submit" value="Add Assertion" />
+            <input name="add-assertion" type="submit" value="Award Individual Badge" />
           </td>
         </tr>
       </table>


### PR DESCRIPTION
"add assertion" sounds very ambiguous and difficult to understand, casting doubt about the button's action

If there is a specific reason why it needs to be "add assertion", please enlighten me :)