### PR TITLE
Add series information to badge page

### DIFF
--- a/tahrir/static/css/tahrir.css
+++ b/tahrir/static/css/tahrir.css
@@ -429,3 +429,8 @@ footer > .document {
 .header > h1 {
     display: inline-block;
 }
+
+.current-badge .thumbnail-container {
+    background: #dfdfef;
+    border-radius: 50%;
+}

--- a/tahrir/templates/badge-base.mak
+++ b/tahrir/templates/badge-base.mak
@@ -165,6 +165,24 @@
         </ul>
       </div> <!-- End padded content. -->
     </div> <!-- End shadow. -->
+    % if related_badges:
+      <div class="shadow">
+        <h1 class="section-header">Series <em>${series_name}</em></h1>
+        <div class="padded-content">
+          <div class="flex-container">
+            % for b in related_badges:
+              % if b[1] == current_idx:
+                <div class="current-badge">
+                  ${self.functions.badge_thumbnail_flex(b[0], 128, 33)}
+                </div>
+              % else:
+                ${self.functions.badge_thumbnail_flex(b[0], 128, 33)}
+              % endif
+            % endfor
+          </div> <!-- End .flex-container -->
+        </div> <!-- End padded content. -->
+      </div> <!-- End shadow. -->
+    % endif
   </div>
 
   <div class="clear spacer"></div>


### PR DESCRIPTION
Add a box to the badge detail page that shows all badges in the same series. The relationship is determined based on badge name. Current badge is highlighted with blue-tinted background.

The assumption on name is that all badges in a series will have a parenthesised series name and a number in the name. The number can be either in Arabic or Roman numerals.

This holds for almost all current badges in Fedora. The only exceptions are:

 * Free the Fedora: has numbers, but not in parentheses
 * Top: Gold, Silver and Bronze are not tied the the others; badges with numbers actually work in the opposite direction (Top 10 is after Top 500 in the series)
 * Editor and Corporate Ant series have no indication that the badges belong together


![snimek z 2016-06-26 19-51-14](https://cloud.githubusercontent.com/assets/89674/16363851/7d724af2-3bd7-11e6-93db-ef7761a06988.png)