### PR TITLE
Add series information to badge page

### DIFF
--- a/tahrir/static/css/tahrir.css
+++ b/tahrir/static/css/tahrir.css
@@ -429,3 +429,8 @@ footer > .document {
 .header > h1 {
     display: inline-block;
 }
+
+.current-badge .thumbnail-container {
+    background: #dfdfef;
+    border-radius: 50% 50% 50% 15%;
+}

--- a/tahrir/templates/badge-base.mak
+++ b/tahrir/templates/badge-base.mak
@@ -165,6 +165,24 @@
         </ul>
       </div> <!-- End padded content. -->
     </div> <!-- End shadow. -->
+    % if related_badges:
+      <div class="shadow">
+        <h1 class="section-header">Series <em>${badge.series}</em></h1>
+        <div class="padded-content">
+          <div class="flex-container">
+            % for b in related_badges:
+              % if b.ordering == badge.ordering:
+                <div class="current-badge">
+                  ${self.functions.badge_thumbnail_flex(b, 128, 33)}
+                </div>
+              % else:
+                ${self.functions.badge_thumbnail_flex(b, 128, 33)}
+              % endif
+            % endfor
+          </div> <!-- End .flex-container -->
+        </div> <!-- End padded content. -->
+      </div> <!-- End shadow. -->
+    % endif
   </div>
 
   <div class="clear spacer"></div>

--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -715,6 +715,12 @@ def badge(request):
     else:
         awarded_assertions = []
 
+    # Get all badges in the same series.
+    related_badges = []
+    if badge.series:
+        related_badges = request.db.get_all_badges().filter(
+            m.Badge.series == badge.series).order_by(sa.asc(m.Badge.ordering)).all()
+
     # Get badge statistics.
     # TODO: Perhaps abstract these statistics methods away somewhere?
     try:
@@ -766,6 +772,7 @@ def badge(request):
             first_awarded_person=first_awarded_person,
             badge_assertions=badge_assertions,
             percent_earned=percent_earned,
+            related_badges=related_badges,
             )
 
 


### PR DESCRIPTION
Add a box to the badge detail page that shows all badges in the same
series. The relationship is stored in the database. Current badge is
highlighted with blue-tinted background.