### PR TITLE
Fix calculation of percentage of top users in the leaderboard

### DIFF
--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -97,7 +97,7 @@ def _get_user_badge_info(request, user):
 
     try:
         percentile = Decimal(float(rank) / float(user_count)).quantize(
-            Decimal('.01'), rounding=ROUND_UP)
+            Decimal('.0001'), rounding=ROUND_UP) * 100
     except ZeroDivisionError:
         percentile = 0
 


### PR DESCRIPTION
The previous change to this calculation is off by two orders of magnitude. (This calculation is also inconsistent with the equivalent version in the leaderboard view function, I haven't addressed that; I don't know if the intent differs here, I'm just fixing the calculation.)