### PR TITLE
Exorcise moksha.wsgi.

### DIFF
--- a/development.ini.example
+++ b/development.ini.example
@@ -5,15 +5,11 @@ port = 8000
 
 [pipeline:main]
 pipeline =
-    moksha
     tw2
     pyramid
 
 [filter:tw2]
 use = egg:tw2.core#middleware
-
-[filter:moksha]
-use = egg:moksha.wsgi#middleware
 
 [app:pyramid]
 
@@ -54,9 +50,6 @@ tahrir.social.twitter_user_text = Check out all these #fedorabadges :trophy:
 tahrir.social.twitter_user_hash = #fedora
 tahrir.social.gplus = True
 
-# TODO -- set this to prod for production.
-tahrir.websocket.topic = org.fedoraproject.stg.fedbadges.badge.award
-
 # If this is true, we'll store the email from the user's FAS account, if
 # not, then we'll use their FAS_USERNAME@fedoraproject.org.  For Fedora
 # Infrastructure we want this to be false due to some inconsistencies between
@@ -69,26 +62,12 @@ tahrir.use_openid_email = False
 # By default, tahrir's own static/ folder contents are used.
 #tahrir.theme_name = tahrir
 
-tahrir.use_websockets = True
-
 # If you leave fedmenu.url undefined, it won't be written to the page at all.
 # https://github.com/fedora-infra/fedmenu
 #fedmenu.url = https://apps.fedoraproject.org/fedmenu
 #fedmenu.data_url = https://apps.fedoraproject.org/js/data.js
 fedmenu.url = http://threebean.org/fedmenu
 fedmenu.data_url = http://threebean.org/fedmenu/dev-data.js
-
-moksha.domain = localhost
-
-moksha.notifications = False
-moksha.socket.notify = False
-
-moksha.livesocket = True
-moksha.livesocket.backend = websocket
-#moksha.livesocket.reconnect_interval = 5000
-moksha.livesocket.websocket.port = 9939
-moksha.livesocket.websocket.host = stg.fedoraproject.org
-moksha.livesocket.websocket.scheme = wss
 
 # Begin logging configuration
 

--- a/production.ini
+++ b/production.ini
@@ -5,15 +5,11 @@ port = 80
 
 [pipeline:main]
 pipeline =
-    moksha
     tw2
     pyramid
 
 [filter:tw2]
 use = egg:tw2.core#middleware
-
-[filter:moksha]
-use = egg:moksha.wsgi#middleware
 
 [app:pyramid]
 
@@ -42,8 +38,6 @@ tahrir.allow_changenick = True
 tahrir.use_fedmsg = True
 tahrir.default_issuer = fedora-project
 
-tahrir.websocket.topic = org.fedoraproject.stg.fedbadges.badge.award
-
 # If this is true, we'll store the email from the user's FAS account, if
 # not, then we'll use their FAS_USERNAME@fedoraproject.org. For Fedora
 # Infrastructure we want this to be false due to some inconsistencies between
@@ -53,20 +47,6 @@ tahrir.use_openid_email = False
 
 # You can optionally create your own CSS theme for tahrir
 # tahrir.static.uri = /home/user/tahrir-theme
-
-tahrir.use_websockets = True
-
-moksha.domain = localhost
-
-moksha.notifications = False
-moksha.socket.notify = False
-
-moksha.livesocket = True
-moksha.livesocket.backend = websocket
-#moksha.livesocket.reconnect_interval = 5000
-moksha.livesocket.websocket.port = 9939
-moksha.livesocket.websocket.host = stg.fedoraproject.org
-moksha.livesocket.websocket.scheme = wss
 
 # Begin logging configuration
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ requires = [
     "dogpile.cache",
     'docutils',
     "python-dateutil",
-    "moksha.wsgi>=1.2.1",
     "webhelpers",
     "requests",
     "rdflib<=4.1.2",

--- a/tahrir/templates/index.mak
+++ b/tahrir/templates/index.mak
@@ -62,9 +62,6 @@
     </div> <!-- End shadow -->
   </div>
 
-  <!-- Set up the moksha live socket -->
-  ${moksha_socket.display() | n}
-
   <div class="clear spacer"></div>
 </div>
 

--- a/tahrir/templates/master.mak
+++ b/tahrir/templates/master.mak
@@ -111,7 +111,7 @@ import json
 			{
 				tryBackgroundLogin('/login', loginSuccess, null);
 			}
-		}	
+		}
 	</script>
   </head>
   <body onload="handleLogin()">
@@ -168,7 +168,7 @@ import json
 
 
         <!-- End of flash message template -->
-      
+
       </div> <!-- End grid-container -->
 
     </div> <!-- End page -->


### PR DESCRIPTION
The backend bits of moksha are py3 ready, but the moksha.wsgi piece is not, plus it has some hairy deps that still need to be ported:

http://fedora.portingdb.xyz/pkg/python-moksha-wsgi/

Let's retire it.  Removing it here to facilitate that.