### PR TITLE
docs: Update README.md Open Badges links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
 # Tahrir
 > fedora-badges https://badges.fedoraproject.org/
 
-Tahrir is an application used by the Fedora Project for issuing
-[Open Badges](https://wiki.mozilla.org/Badges).
+Tahrir is an application used by the Fedora Project for issuing [Open
+Badges][open-badges].  As per the [about][ob-about] page:
 
-Tahrir is [Arabic for Liberation](http://en.wikipedia.org/wiki/Tahrir_Square).
+> The concept of Open Badges originated among those working at the Mozilla and
+> MacArthur foundations, and out of the research of Erin Knight, founding
+> director of the Open Badges project at Mozilla. 
+
+Originally, information was hosted on the [Mozilla Wiki][moz-badges].
+
+Tahrir is [Arabic for Liberation][wikipedia-tahrir]
 
 ## Contributing
 
 To get started contributing content, see the [Contributing
-guide](https://github.com/fedora-infra/tahrir/blob/develop/CONTRIBUTING.md),
-To setup your development environment, see the [Developing guide](https://github.com/fedora-infra/tahrir/blob/develop/DEVELOPING.md)
+guide][contributing].  To setup your development environment, see the
+[Developing guide][developing].
+
+[open-badges]: https://openbadges.org
+[ob-about]: https://openbadges.org/about/
+[moz-badges]: https://wiki.mozilla.org/index.php?title=Badges&oldid=1170927
+[wikipedia-tahrir]: http://en.wikipedia.org/wiki/Tahrir_Square
+[contributing]: https://github.com/fedora-infra/tahrir/blob/develop/CONTRIBUTING.md
+[developing]: https://github.com/fedora-infra/tahrir/blob/develop/DEVELOPING.md


### PR DESCRIPTION
Update all links to move from the mozilla wiki to openbadges.org.

Additionally, add a historic note and (since the link to the mozilla
wiki is in danger of being purged) changing it to a specific revision in
the history.

In tandem this page was put in the Wayback machine hosted by the
Internet Archive in the event of link rot:

https://web.archive.org/web/20190418175812/https://wiki.mozilla.org/Badges

Resolves #424

Signed-off-by: Brian 'Redbeard' Harrington <redbeard@dead-city.org>