### PR TITLE
Initial Python 3 port

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ requires = [
     "requests",
     "rdflib<=4.1.2",
     "pytz",
+    "six",
 
     # For qrcode to work from PyPI, you also need Pillow.
     # This is handled for us in Fedora because python-qrcode pulls in the

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ requires = [
     'transaction',
     'pyramid_tm',
     'zope.sqlalchemy',
-    "weberror",
     'velruse',
     "qrcode",
     "dogpile.cache",

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,10 @@ requires = [
     "dogpile.cache",
     'docutils',
     "python-dateutil",
-    "webhelpers",
+    "feedgen",
     "requests",
     "rdflib<=4.1.2",
+    "pytz",
 
     # For qrcode to work from PyPI, you also need Pillow.
     # This is handled for us in Fedora because python-qrcode pulls in the

--- a/tahrir/app.py
+++ b/tahrir/app.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from pyramid.security import Allow, Deny, Everyone
 
 

--- a/tahrir/custom_openid.py
+++ b/tahrir/custom_openid.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import velruse.api
 import velruse.providers.openid as vr
 

--- a/tahrir/events.py
+++ b/tahrir/events.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from pyramid.events import (
     subscriber,
     BeforeRender,

--- a/tahrir/notifications.py
+++ b/tahrir/notifications.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pyramid.threadlocal
 from pyramid.settings import asbool
 

--- a/tahrir/templates/index.mak
+++ b/tahrir/templates/index.mak
@@ -25,7 +25,7 @@
     <div class="shadow">
       <h1 class="section-header">Weekly Leaders</h1>
       <div class="padded-content">
-        % for person in weekly_leaders.keys()[:n]:
+        % for person in list(weekly_leaders.keys())[:n]:
           <div class="grid-container">
             ${self.functions.avatar_thumbnail(person, 64, 33)}
             <div class="grid-66 text-64">
@@ -46,7 +46,7 @@
     <div class="shadow">
       <h1 class="section-header">Monthly Leaders</h1>
       <div class="padded-content">
-        % for person in monthly_leaders.keys()[:n]:
+        % for person in list(monthly_leaders.keys())[:n]:
           <div class="grid-container">
             ${self.functions.avatar_thumbnail(person, 64, 33)}
             <div class="grid-66 text-64">

--- a/tahrir/templates/report.mak
+++ b/tahrir/templates/report.mak
@@ -6,7 +6,7 @@
       <div class="padded-content">
         <p>Looking for the <a href="${request.route_url('leaderboard')}">all-time leaderboard?</a></p>
         <table>
-          % for person, stats in user_to_rank.items()[:25]:
+          % for person, stats in list(user_to_rank.items())[:25]:
             <tr>
               <td style="width: 20px;">
                   <span class="big-text">#${stats['rank']}</span>

--- a/tahrir/views.py
+++ b/tahrir/views.py
@@ -45,7 +45,6 @@ import tahrir_api.model as m
 
 from tahrir.utils import generate_badge_yaml
 from tahrir_api.utils import convert_name_to_id
-import foafutils
 
 
 def _get_user(request, id_or_nickname):

--- a/tahrir/widgets.py
+++ b/tahrir/widgets.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import tahrir_api.model as m
 
 import hashlib
@@ -16,7 +17,7 @@ log = logging.getLogger(__name__)
 def scale_to_standard_size(filename):
     try:
         import magickwand.image as magick
-    except Exception, e:
+    except Exception as e:
         log.warn(str(e))
         log.warn("Did not scale image to standard size")
         return

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,3 +13,25 @@ class TestSingularize(unittest.TestCase):
     def test_singularize_value_1(self):
         """Test that the trailing letter is returned when value is 1."""
         self.assertEqual(utils.singularize('cats', 1), 'cat')
+
+
+class TestMergeDicts(unittest.TestCase):
+    """Test the merge_dicts() function."""
+
+    def test_merge_dicts(self):
+        dict1 = {1: 'a'}
+        dict2 = {2: ['b']}
+        self.assertEqual(utils.merge_dicts(dict1, dict2), {1: 'a', 2: ['b']})
+
+
+class TestStrToBytes(unittest.TestCase):
+    """Test the str_to_bytes() function."""
+
+    def test_str_to_bytes_str(self):
+        self.assertEqual(utils.str_to_bytes('foo'), b'foo')
+
+    def test_str_to_bytes_bytes(self):
+        self.assertEqual(utils.str_to_bytes(b'foo'), b'foo')
+
+    def test_str_to_bytes_other(self):
+        self.assertEqual(utils.str_to_bytes(['list']), ['list'])


### PR DESCRIPTION
These changes together make Tahrir work at least to some extent on Python 3, for me, using latest git tahrir-api with [this PR](https://github.com/fedora-infra/tahrir-api/pull/47). Everything I poked and tested so far works, of course the test suite is basically non-existent so it's hard to know what else lurks. I at least tested creating badges, awarding them, poking around the web UI a bit, loading JSON and RSS feeds and stuff.