### PR TITLE
Add dnf cache directory to Vagrantfile. Remove ansible prereqs as they don't seem to be need anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ secret.ini
 .DS_STORE
 development.ini
 *.ropeproject
+.dnf-cache
+.vagrant

--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -9,8 +9,10 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.synced_folder ".", "/vagrant", type: "sshfs"
 
-  # Ansible needs the guest to have these
-  config.vm.provision "shell", inline: "sudo dnf install -y libselinux-python python2-dnf"
+  # To cache update packages (which is helpful if frequently doing vagrant destroy && vagrant up)
+  # you can create a local directory and share it to the guest's DNF cache. Comment the line below
+  # to not use a dnf cache directory
+  config.vm.synced_folder ".dnf-cache", "/var/cache/dnf", type: "sshfs", owner: "root", group: "root", create: true, sshfs_opts_append: "-o idmap=user"
 
   config.vm.provision "ansible" do |ansible|
       ansible.playbook = "devel/ansible/playbook.yml"


### PR DESCRIPTION
Been trying out the vagrantfile for this project and seems like the ansible prereqs aren't needed just to run ansible, please correct me if I'm wrong.

Also took inspiration from some code from the [Fedora wiki](https://fedoraproject.org/wiki/Vagrant) where they implemented a dnf cache using sshfs in vagrant.

Adds the .dnf-cache and .vagrant directories to .gitignore.