### PR TITLE
Fix URL generation for RSS

### DIFF
--- a/tahrir/templates/master.mak
+++ b/tahrir/templates/master.mak
@@ -54,16 +54,16 @@ import json
     <title>${title}</title>
 
     % if user or badge:
-    <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="${request.url}/rss" />
-    <link rel="alternate" type="application/json" title="JSON" href="${request.url}/json" />
+    <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="${request.path_url}/rss" />
+    <link rel="alternate" type="application/json" title="JSON" href="${request.path_url}/json" />
     % endif
 
     %if newest_badges:
-    <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="${request.url}/rss" />
+    <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="${request.path_url}/rss" />
     % endif
 
     % if user:
-    <link rel="alternate" type="application/rdf" title="RDF+FOAF" href="${request.url}/foaf" />
+    <link rel="alternate" type="application/rdf" title="RDF+FOAF" href="${request.path_url}/foaf" />
     % endif
 
 	<script type="text/javascript" src="//apps.fedoraproject.org/global/js/jsautologin.js">


### PR DESCRIPTION
We have a bunch of 500 errors since URL like
https://badges.fedoraproject.org/user/misc?history_limit=42 generate
a link to user/misc?history_limit=42/rss, which in turn cause trouble
since 42/rss can't be turned into a int, generating a traceback:

    File "/usr/lib/python2.7/site-packages/pyramid/router.py", line 163, in handle_request
      response = view_callable(context, request)
    File "/usr/lib/python2.7/site-packages/pyramid/config/views.py", line 355, in rendered_view
      result = view(context, request)
    File "/usr/lib/python2.7/site-packages/pyramid/config/views.py", line 501, in _requestonly_view
      response = view(request)
    File "/usr/lib/python2.7/site-packages/tahrir/views.py", line 1042, in user
      history_limit = int(request.params.get('history_limit', 10))
    ValueError: invalid literal for int() with base 10: '42/rss'