### PR TITLE
Add a default value for secure cookie

### DIFF
--- a/tahrir/__init__.py
+++ b/tahrir/__init__.py
@@ -105,14 +105,14 @@ def main(global_config, **settings):
         secret=settings['authnsecret'],
         callback=groupfinder, # groupfinder callback checks for admin privs
         hashalg='sha512', # because md5 is deprecated
-        secure=asbool(settings['tahrir.secure_cookies']),
-        http_only=asbool(settings['tahrir.httponly_cookies']),
+        secure=asbool(settings.get('tahrir.secure_cookies', True)),
+        http_only=asbool(settings.get('tahrir.httponly_cookies', True)),
     )
     authz_policy = ACLAuthorizationPolicy()
     session_factory = SignedCookieSessionFactory(
         secret=settings['session.secret'],
-        cookie_secure=asbool(settings['tahrir.secure_cookies']),
-        cookie_httponly=asbool(settings['tahrir.httponly_cookies']),
+        cookie_secure=asbool(settings.get('tahrir.secure_cookies', True)),
+        cookie_httponly=asbool(settings.get('tahrir.httponly_cookies', True)),
     )
 
     # Configure our cache that we instantiated earlier.


### PR DESCRIPTION
having a default value help wrt deployment on Openshift, since that's one less value to care about. I am not sure why this is a setting in the 1st place, but default should be secure.