### PR TITLE
Point tox-github-action to the correct branch

### DIFF
--- a/.github/workflows/github-tox.yml
+++ b/.github/workflows/github-tox.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: fedora-python/tox-github-action@master
+      - uses: fedora-python/tox-github-action@main
         with:
           # The tox environment to run
           # Default: py38 (subject to change as new Python releases come out)


### PR DESCRIPTION
Tox-github-action branch is now named main
As seen here: https://github.com/fedora-python/tox-github-action