### PR TITLE
fix: Change url path of `Fedora account`

### DIFF
--- a/fedora-sitedocs/about.rst
+++ b/fedora-sitedocs/about.rst
@@ -9,7 +9,7 @@ Fedora Badges
 How does Badges work?
 ---------------------
 
-It's really easy! Just `sign in to Badges <https://badges.fedoraproject.org/oidc/login>`_ with your `Fedora account <https://admin.fedoraproject.org/accounts/>`_, and you'll see you have at least one badge right away. Congratulations - you're a Badger! If you participate in Fedora in any way, you'll probably notice Badges popping up on your profile as you go about your business, though sadly we don't cover every area of Fedora yet - we're doing our best to make sure we reward as many forms of participation as we can!
+It's really easy! Just `sign in to Badges <https://badges.fedoraproject.org/oidc/login>`_ with your `Fedora account <https://accounts.fedoraproject.org/>`_, and you'll see you have at least one badge right away. Congratulations - you're a Badger! If you participate in Fedora in any way, you'll probably notice Badges popping up on your profile as you go about your business, though sadly we don't cover every area of Fedora yet - we're doing our best to make sure we reward as many forms of participation as we can!
 
 Want to see how your badge collection compares with others? Check the `Leaderboard <https://badges.fedoraproject.org/leaderboard>`_. Jonesing for more badges? You can check the `Badge index <https://badges.fedoraproject.org/explore/badges>`_ to see all the badges and get to work on your collection! Click on a badge to see how to get it - but
 we intentionally didn't spell it all out exactly. Part of the fun is figuring it out!


### PR DESCRIPTION
Hi,

This PR should fix the broken url path mentioned in issue #638 

> It's really easy! Just [sign in to Badges](https://badges.fedoraproject.org/oidc/login) with your [Fedora account](https://admin.fedoraproject.org/accounts/), and you'll see you have at least one badge right away.

Fixes: #638 

I could not test it as I was not able to setup `tahrir` locally with vagrant. In docs it's mentioned to have `tiny-stage` setup first, is it necessary? Can `tahrir` be setup without it? Any help in this matter would be helpful.