### PR TITLE
Implement global search feature that searches through users and badges

### DIFF
--- a/tahrir/views/explore.py
+++ b/tahrir/views/explore.py
@@ -1,12 +1,12 @@
 import random
-from datetime import date, datetime, timedelta, timezone
-
-from tahrir.defaults import TAHRIR_DISPLAY_TAGS
+from datetime import date, timedelta, timezone
 
 import sqlalchemy as sa
 import tahrir_api.model as m
 from feedgen.feed import FeedGenerator
 from flask import g, jsonify, redirect, render_template, request, url_for
+
+from tahrir.defaults import TAHRIR_DISPLAY_TAGS
 
 from ..utils.badge import sort_badges_by_tag
 from . import blueprint as bp
@@ -77,6 +77,55 @@ def explore():
         example_date=date.today() - timedelta(days=31),
     )
 
+@bp.route("/json/search/<search_query>", methods=["GET"])
+def json_explore(search_query):
+    """
+    Global search endpoint that returns users and badges.
+    Returns a dictionary containing all available users and badges.
+    """
+
+    # Get all badges
+    all_badges = g.tahrirdb.get_all_badges().filter(
+        sa.func.lower(m.Badge.name).like(f"%{search_query.lower()}%") |
+        sa.func.lower(m.Badge.description).like(f"%{search_query.lower()}%") |
+        sa.func.lower(m.Badge.tags).like(f"%{search_query.lower()}%")
+    ).all()
+    badges_data = [
+        {
+            "id": badge.id,
+            "created_on": badge.created_on.timestamp() if badge.created_on else None,
+            "description": badge.description,
+            "image": badge.image,
+            "name": badge.name,
+            "tags": [
+                tag.strip() for tag in badge.tags.split(",") if tag.strip()
+            ] if badge.tags else []
+        } for badge in all_badges
+    ]
+
+    # Get all users (persons who haven't opted out)
+    all_persons = g.tahrirdb.get_all_persons().filter(
+        m.Person.opt_out.is_(False) &
+        sa.func.lower(m.Person.nickname).like(f"%{search_query.lower()}%")
+    ).all()
+    users_data = [
+        {
+            "id": person.id,
+            "bio": person.bio if person.bio else None,
+            "created_on": person.created_on.timestamp() if person.created_on else None,
+            "email": person.email,
+            "last_login": person.last_login.timestamp() if person.last_login else None,
+            "nickname": person.nickname,
+            "rank": person.rank,
+            "website": person.website
+        } for person in all_persons
+    ]
+
+    return jsonify({
+        "users": users_data,
+        "badges": badges_data
+    })
+
 
 @bp.route("/explore/badges")
 def explore_badges():
@@ -123,8 +172,16 @@ def json_discover_accolade():
         } for badge in newest_badges
     ]
 
-    serializable_all_badges_by_tag = {name: [indx for indx, item in enumerate(serializable_all_badges) if name in item["tags"]] for name in TAHRIR_DISPLAY_TAGS}
-    serializable_newest_badges_by_tag = {name: [indx for indx, item in enumerate(serializable_newest_badges) if name in item["tags"]] for name in TAHRIR_DISPLAY_TAGS}
+    serializable_all_badges_by_tag = {
+        name: [
+            indx for indx, item in enumerate(serializable_all_badges) if name in item["tags"]
+        ] for name in TAHRIR_DISPLAY_TAGS
+    }
+    serializable_newest_badges_by_tag = {
+        name: [
+            indx for indx, item in enumerate(serializable_newest_badges) if name in item["tags"]
+        ] for name in TAHRIR_DISPLAY_TAGS
+    }
 
     data = {
         "classified": {

--- a/tahrir/views/user.py
+++ b/tahrir/views/user.py
@@ -4,12 +4,11 @@ from decimal import Decimal, ROUND_UP
 from feedgen.feed import FeedGenerator
 from flask import abort, g, jsonify, render_template, request, url_for
 
-from tahrir.utils.avatar import get_avatar
 from tahrir.utils.badge import badge_json_generator, sort_badges_by_tag
 from tahrir.utils.user import get_person
 
-from . import blueprint as bp
 from ..defaults import TAHRIR_DISPLAY_TAGS
+from . import blueprint as bp
 
 
 def _get_user_badge_info(person):


### PR DESCRIPTION
This PR adds global search endpoint `/json/search/<search_query>` that allows searching across badges and users.

The endpoint returns filtered results based on search query matching badge names, descriptions, tags, and user nicknames.

<img width="825" height="1039" alt="image" src="https://github.com/user-attachments/assets/ed2fd4bd-807d-426d-85e9-8633fb0b67a2" />
<img width="613" height="430" alt="image" src="https://github.com/user-attachments/assets/66542841-9e77-4e2d-9f98-396aac0df5ce" />

Fixes: #665 