### PR TITLE
Add endpoint for fetching badges by tag

### DIFF
--- a/tahrir/views/badge.py
+++ b/tahrir/views/badge.py
@@ -253,6 +253,30 @@ def tags(tags, match):
     )
 
 
+@bp.route("/json/category/<string:name>")
+def json_badges_from_tag(name):
+    """Endpoint to fetch the badges based on matching tag."""
+
+    tag = [name.strip()]
+    badges = g.tahrirdb.get_badges_from_tags(tags=tag, match_all=False)
+
+    serializable_badges = sorted(
+        [
+            {
+                "name": badge.name,
+                "image": badge.image,
+                "description": badge.description,
+                "created_on": badge.created_on.timestamp(),
+                "tags": [item for item in badge.tags.split(",") if item.strip() != ""],
+                "id": badge.id,
+            } for badge in badges
+        ],
+        key= lambda x: x["name"]
+    )
+
+    return jsonify(serializable_badges)
+
+
 # delegated admin endpoints
 
 


### PR DESCRIPTION
@gridhead, I created this PR after our discussion for the need of fetching the list of badges once the tags are clicked in the frontend

<img width="1915" height="600" alt="image" src="https://github.com/user-attachments/assets/a9935860-9ca1-4c99-a2a8-73dba2e3846b" />
<img width="1915" height="283" alt="image" src="https://github.com/user-attachments/assets/f9695eaf-dfaa-485a-9abe-6e2687809e25" />

<hr>

This PR adds endpoint `/json/category/<string:name>` that fetches the list of badges based on the provided tag and then returns them alphabetically by name.

<img width="781" height="1035" alt="image" src="https://github.com/user-attachments/assets/0b7ea7d0-5907-439c-8209-c0f192c2138b" />
<img width="781" height="1035" alt="image" src="https://github.com/user-attachments/assets/39e6e280-8d97-44bb-b1cd-67896efaf32e" />

Thank you for creating the required issue for tracking purpose.