### PR TITLE
Add `CRUD` REST API endpoints for `ASSERTIONS` relation

### DIFF
--- a/tahrir/endpoints/admin/assertions.py
+++ b/tahrir/endpoints/admin/assertions.py
@@ -1,0 +1,41 @@
+from flask import abort, g, jsonify, request
+
+from ...app import csrf, oidc
+from ...utils.user import require_admin
+from . import blueprint as bp
+
+
+@bp.route("/api/admin/assertions", methods=["POST"])
+@csrf.exempt
+@oidc.require_login
+@require_admin
+def create_assertion():
+    """Endpoint to create a new assertion (award badge)."""
+
+    data = request.get_json()
+    if not data:
+        return abort(400, "No details provided")
+
+    required_fields = ["badge_id", "person_email"]
+    for field in required_fields:
+        if not data.get(field):
+            return abort(400, f"No detail provided for {field!r}")
+
+    badge_id = data.get("badge_id")
+    person_email = data.get("person_email")
+
+    # Check if assertion already exists
+    if g.tahrirdb.assertion_exists(badge_id, person_email):
+        return abort(409, f"User {person_email!r} already has badge {badge_id!r}")
+
+    result = g.tahrirdb.add_assertion(
+        badge_id=badge_id,
+        person_email=person_email,
+        issued_on=data.get("issued_on"),
+        issued_for=data.get("issued_for"),
+    )
+
+    if not result:
+        return abort(400, "Failed to create assertion")
+
+    return jsonify({"message": f"Badge {badge_id!r} awarded to {person_email!r}"}), 201

--- a/tahrir/endpoints/assertions.py
+++ b/tahrir/endpoints/assertions.py
@@ -1,0 +1,33 @@
+from flask import abort, g, jsonify, request
+
+from . import blueprint as bp
+
+
+@bp.route("/api/assertions/<string:badge_id>", methods=["GET"])
+def get_assertions_by_badge(badge_id: str):
+    """Endpoint to fetch all assertions for a specific badge."""
+
+    assertions = sorted(
+        g.tahrirdb.get_assertions_by_badge(badge_id), key=lambda assertion: assertion.issued_on
+    )
+
+    if assertions is False:
+        return abort(404, f"No such badge {badge_id!r}")
+
+    if not assertions:
+        return jsonify([])
+
+    # This is a very unoptimised implementation for achieving pagination.
+    # The implemenation should have been there in the upstream `tahrir-api` at database level.
+    begin = request.args.get("begin", 0, type=int)
+    limit = request.args.get("limit", 100, type=int)
+
+    result = []
+    for assertion in assertions[begin : begin + (limit if limit < 100 else 100)]:
+        assertion_data = assertion.as_dict()
+        assertion_data.pop("badge", None)  # Remove unwanted fields
+        assertion_data["person"] = assertion.person.as_dict()  # Add user info
+        assertion_data["person"]["avatar"] = assertion.person.avatar  # Add user avatar
+        result.append(assertion_data)
+
+    return jsonify(result)

--- a/tahrir/endpoints/badges.py
+++ b/tahrir/endpoints/badges.py
@@ -46,7 +46,7 @@ def get_badge_by_id(badge_id: str):
 
     badge = get_badge_or_404(badge_id)
 
-    return jsonify(badge_json_generator(badge))
+    return jsonify(badge_json_generator(badge, withasserts=False))
 
 
 @bp.route("/api/badges/category/<string:name>", methods=["GET"])


### PR DESCRIPTION
This PR implements the core REST API infrastructure for performing CRUD operations on `ASSERTIONS` relation (except update and delete)

Key changes:
- Added new endpoints module with public assertion read operations
- Added admin endpoints module with authenticated create operation

Endpoints added:
- GET /api/assertions/<badge_id> - fetch all the assertions for the specified badge
- GET /api/assertions/user/<email> - fetch all assertions for the specific user
- POST /api/admin/assertions - create new assertions (admin only)

Note: Full CRUD operations require new database functions in [tahrir-api](https://github.com/fedora-infra/tahrir-api/issues/198) first: 
- Get latest assertions - current implementation uses direct query even tough separate repo [tahrir-api](https://github.com/fedora-infra/tahrir-api) exists. I'm not sure why the current implementation is the way it is. If a repo specifically is present for accessing the DB why do we need to perform it here.
https://github.com/fedora-infra/tahrir/blob/a8517ded937a9ee89ccaf5f7fd9694e0fe210a93/tahrir/views/root.py#L17
- Delete assertion - for DELETE operations
- Update assertion - for UPDATE operations

Thank you for reviewing this PR and let me know if any modifications are needed. In the meanwhile, please confirm if I should go ahead and add the above mentioned operations in [tahrir-api](https://github.com/fedora-infra/tahrir-api)?

Fixes: #692 