### PR TITLE
Add CRUD REST API endpoints for PERSONS relation

### DIFF
--- a/tahrir/endpoints/admin/users.py
+++ b/tahrir/endpoints/admin/users.py
@@ -1,0 +1,33 @@
+from flask import abort, g, jsonify, request
+
+from ...app import csrf, oidc
+from ...utils.user import require_admin
+from . import blueprint as bp
+
+
+@bp.route("/api/admin/users", methods=["POST"])
+@csrf.exempt
+@oidc.require_login
+@require_admin
+def add_user():
+    """Endpoint to add a new user"""
+
+    data = request.get_json()
+    if not data:
+        return abort(400, "No details provided")
+
+    if not data.get("email"):
+        return abort(400, "No email id is provided")
+
+    if g.tahrirdb.person_exists(email=data.get("email")):
+        abort(409, f"Person with email {data.get('email')!r} already exists.")
+
+    g.tahrirdb.add_person(
+        email=data.get("email"),
+        nickname=data.get("nickname"),
+        website=data.get("website"),
+        bio=data.get("bio"),
+        avatar=data.get("avatar"),
+    )
+
+    return jsonify({"message": f"User {data.get('email')!r} added successfully"}), 201

--- a/tahrir/endpoints/assertions.py
+++ b/tahrir/endpoints/assertions.py
@@ -7,15 +7,15 @@ from . import blueprint as bp
 def get_assertions_by_badge(badge_id: str):
     """Endpoint to fetch all assertions for a specific badge."""
 
-    assertions = sorted(
-        g.tahrirdb.get_assertions_by_badge(badge_id), key=lambda assertion: assertion.issued_on
-    )
+    assertions = g.tahrirdb.get_assertions_by_badge(badge_id)
 
     if assertions is False:
         return abort(404, f"No such badge {badge_id!r}")
 
     if not assertions:
         return jsonify([])
+
+    assertions = sorted(assertions, key=lambda assertion: assertion.issued_on)
 
     # This is a very unoptimised implementation for achieving pagination.
     # The implementation should have been there in the upstream `tahrir-api` at database level.

--- a/tahrir/endpoints/users.py
+++ b/tahrir/endpoints/users.py
@@ -1,7 +1,8 @@
 import sqlalchemy as sa
 import tahrir_api.model as m
-from flask import g, jsonify, request
+from flask import abort, g, jsonify, request
 
+from ..utils.user import get_person, get_user_badge_info, require_login
 from . import blueprint as bp
 
 
@@ -44,3 +45,129 @@ def search_users_by_string(search_string: str):
     }
 
     return jsonify(result)
+
+
+@bp.route("/api/users/<string:user_id>", methods=["GET"])
+def get_user_by_id(user_id: str):
+    """Endpoint to fetch the user based on matching id."""
+
+    user = get_person(user_id)
+
+    if not user:
+        abort(404, f"No such user {user_id!r}")
+
+    if user.opt_out and user.email != g.oidc_user.email:
+        abort(404, f"User {user_id!r} has opted out.")
+
+    # Get badge info using utility function
+    badges_info = get_user_badge_info(user)
+
+    return jsonify(
+        {
+            "user": {
+                "nickname": user.nickname,
+                "mail": user.avatar,
+                "created_on": user.created_on if user.created_on else None,
+                "opt_out": user.opt_out,
+                "rank": badges_info["rank"],
+            },
+            **badges_info,
+        }
+    )
+
+
+@bp.route("/api/users/opt_out", methods=["PUT"])
+@require_login
+def update_user_by_id():
+    """Endpoint to update user account settings."""
+
+    data = request.get_json()
+    if not data.get("opt_out"):
+        abort(400, "No data provided")
+
+    g.oidc_user.person.opt_out = data.get("opt_out")
+
+    return jsonify({"message": "User updated successfully"})
+
+
+@bp.route("/api/users/diff/<string:id_a>/<string:id_b>", methods=["GET"])
+@require_login
+def get_user_diff(id_a: str, id_b: str):
+    """Endpoint to compare badges between two users."""
+
+    user_a = get_person(id_a)
+    user_b = get_person(id_b)
+
+    if not user_a:
+        abort(404, f"No such user {id_a!r}")
+    if not user_b:
+        abort(404, f"No such user {id_b!r}")
+
+    if user_a.opt_out and user_a.email != g.oidc_user.email:
+        abort(404, f"User {id_a!r} has opted out.")
+    if user_b.opt_out and user_b.email != g.oidc_user.email:
+        abort(404, f"User {id_b!r} has opted out.")
+
+    if user_a.email != g.oidc_user.email:
+        abort(401)
+
+    # Get badge info using utility function
+    user_a_info = get_user_badge_info(user_a)
+    user_b_info = get_user_badge_info(user_b)
+
+    # Get raw badge objects for diffing
+    user_a_badges = [a.badge for a in user_a.assertions]
+    user_b_badges = [a.badge for a in user_b.assertions]
+
+    # Diff badges
+    user_a_unique_badges = []
+    user_b_unique_badges = []
+    combined_badges = list(sorted(set(user_a_badges + user_b_badges), key=lambda badge: badge.id))
+    shared_badges = []
+    for badge in combined_badges:
+        if badge in user_a_badges and badge not in user_b_badges:
+            user_a_unique_badges.append(badge)
+        elif badge in user_b_badges and badge not in user_a_badges:
+            user_b_unique_badges.append(badge)
+        elif badge in user_a_badges and badge in user_b_badges:
+            shared_badges.append(badge)
+
+    return jsonify(
+        {
+            "user_a": {
+                "id": user_a.id,
+                "nickname": user_a.nickname,
+                "email": user_a.email,
+                "avatar": user_a.avatar,
+                "badges_count": len(user_a_info["badges"]),
+                "percent_earned": user_a_info["percent_earned"],
+                "rank": user_a_info["rank"],
+                "percentile": user_a_info["percentile"],
+            },
+            "user_b": {
+                "id": user_b.id,
+                "nickname": user_b.nickname,
+                "email": user_b.email,
+                "avatar": user_b.avatar,
+                "badges_count": len(user_b_info["badges"]),
+                "percent_earned": user_b_info["percent_earned"],
+                "rank": user_b_info["rank"],
+                "percentile": user_b_info["percentile"],
+            },
+            "user_a_badges": user_a_info["badges"],
+            "user_b_badges": user_b_info["badges"],
+            "user_a_unique_badges": [
+                b
+                for b in user_a_info["badges"]
+                if any(ub.id == b["id"] for ub in user_a_unique_badges)
+            ],
+            "user_b_unique_badges": [
+                b
+                for b in user_b_info["badges"]
+                if any(ub.id == b["id"] for ub in user_b_unique_badges)
+            ],
+            "shared_badges": [
+                b for b in user_a_info["badges"] if any(sb.id == b["id"] for sb in shared_badges)
+            ],
+        }
+    )

--- a/tahrir/utils/user.py
+++ b/tahrir/utils/user.py
@@ -4,6 +4,10 @@ from urllib.parse import quote_plus
 from flask import abort, current_app, g, redirect, request, session, url_for
 from flask_oidc.model import User as OIDCUser
 
+from tahrir.defaults import TAHRIR_DISPLAY_TAGS
+
+from .badge import badge_json_generator
+
 
 class User(OIDCUser):
     def __init__(self, ext):
@@ -152,3 +156,50 @@ def require_admin(view_func):
         return view_func(*args, **kwargs)
 
     return decorated
+
+
+def get_user_badge_info(user):
+    """Returns a dictionary of the user badge information with serialized badges"""
+
+    # Get user badges
+    badges = [assertion.badge for assertion in user.assertions]
+
+    # Get total number of unique badges in the system
+    total_badges = g.tahrirdb.get_all_badges().count()
+
+    # Get percentage of badges earned by user
+    percent_earned = (float(len(badges)) / float(total_badges)) * 100 if total_badges > 0 else 0
+
+    # Get rank of user
+    rank = user.rank or 0
+
+    # Get total number of users
+    user_count = g.tahrirdb.get_all_persons().count()
+
+    # Get users standing
+    percentile = round((rank / user_count) * 100, 2) if user_count > 0 else 0
+
+    # Get user assertions
+    assertions = sorted(user.assertions, key=lambda item: item.issued_on, reverse=True)
+
+    # Initialize empty list to store serailized badges
+    serialized_badges = []
+
+    # Set the classifications of the badges
+    classified = {name: [] for name in TAHRIR_DISPLAY_TAGS}
+
+    for indx, item in enumerate(assertions):
+        badge = badge_json_generator(item.badge, withasserts=False)
+        serialized_badges.append({**badge})
+        for name in classified.keys():
+            if name in item.badge.tags:
+                classified[name].append(indx)
+
+    return {
+        "badges": serialized_badges,
+        "classified": classified,
+        "percentile": percentile,
+        "percent_earned": round(percent_earned, 2),
+        "rank": rank,
+        "total_badges": total_badges,
+    }


### PR DESCRIPTION
This PR adds REST API endpoints for user (`PERSONS`) relation.

Key Changes:
 - Added new endpoint for fetching specific user details including badges, invitations, rank, and percentile
 - Added new endpoint for generating the diff between two users (the one who want to compare has to be logged in)
 - Added new endpoint for adding user in the database. I'm very sceptical about this one. If we are using OIDC for the user account creation, shouldn't only user be able to create the account? Why do admin be able to do it?
- Added new endpoint for deactivating or deactivating users account

Endpoints added:
- GET /api/users/ - Fetch specific user details including badges, invitations, rank, and percentile
- GET /api/users/diff/ - Compare badges between two users, showing unique and shared badges (requires login)
- POST /api/admin/users - Adds new user the the database 
- PUT /api/users - Deactivates or reactivates users account (requires login)

Note: Full CRUD operations require new database functions in [tahrir-api](https://github.com/fedora-infra/tahrir-api/issues/200) first:
 - Delete user - for DELETE operations
 https://github.com/fedora-infra/tahrir-api/blob/6c36987df0593937f4c061d1424c0dd426e43891/tahrir_api/dbapi.py#L547C1-L560C21
 Delete is present but CASCADE delete is not enable in the database
 - Update user - for UPDATE operations

Thank you for reviewing this PR and let me know if any modifications are needed.