### PR TITLE
Add `DELETE` endpoint for `ASSERTION` relation

### DIFF
--- a/tahrir/endpoints/admin/assertions.py
+++ b/tahrir/endpoints/admin/assertions.py
@@ -51,3 +51,36 @@ def create_assertion():
         return abort(400, "Failed to create assertion")
 
     return jsonify({"message": f"Badge {badge_id!r} awarded to {person_email!r}"}), 201
+
+
+@bp.route("/api/admin/assertions", methods=["DELETE"])
+@csrf.exempt
+@oidc.require_login
+@require_admin
+def remove_assertion():
+    """Endpoint to remove an assertion (retract awarded badge)."""
+
+    data = request.get_json()
+    if not data:
+        return abort(400, "No details provided")
+
+    required_fields = ["badge_id", "username"]
+    for field in required_fields:
+        if not data.get(field):
+            return abort(400, f"No detail provided for {field!r}")
+
+    badge_id = data.get("badge_id")
+    username = data.get("username")
+
+    # TODO: Modularize this to variable
+    person_email = f"{username}@fedoraproject.org"
+
+    result = g.tahrirdb.remove_assertion(
+        badge_id=badge_id,
+        person_email=person_email,
+    )
+
+    if not result:
+        return abort(404, f"Badge {badge_id!r} or User {person_email!r} or Assertion not found")
+
+    return jsonify({"message": f"Badge {badge_id!r} retracted from {person_email!r}"})


### PR DESCRIPTION
Implement `DELETE` endpoint to allow admins to retract awarded badges from users.

## Summary
- Add DELETE endpoint at `/api/admin/assertions` to enable badge retraction functionality
- Implements admin-only access control
- Validates required fields (badge_id, username) before processing

## Changes
- New `remove_assertion()` endpoint in `tahrir/endpoints/admin/assertions.py`
- Constructs person_email from username (TODO: modularize email construction)
- Returns 404 if badge, user, or assertion not found
- Returns success message upon successful retraction

<img width="1920" height="403" alt="Screenshot From 2025-11-04 22-03-53" src="https://github.com/user-attachments/assets/0a276c9d-a639-4562-926b-6112d913d0f2" />

Fixes: #692 