### PR TITLE
Add `POST` REST API endpoints for `AUTHORIZATION` relation

### DIFF
--- a/frontend/src/crud/authorizations/create.jsx
+++ b/frontend/src/crud/authorizations/create.jsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react";
+import { Button, Card, Col, Dropdown, FloatingLabel, Form, Image, Row } from "react-bootstrap";
+import { useDispatch } from "react-redux";
+
+import { useCreationSanctionMutation, useLookupAccoladeQuery, useLookupIdentityQuery } from "../../features/call.js";
+import { hideLoad, showBaseNote, showLoad } from "../../features/part.js";
+import { portraitProvider } from "../../features/util.js";
+
+export default function AuthorizationCreationForm() {
+  const dispatch = useDispatch();
+  const [creationSanction, { isLoading }] = useCreationSanctionMutation();
+
+  const [form, makeForm] = useState({
+    badge_id: "",
+    user: "",
+  });
+
+  const [accoladeLookup, setAccoladeLookup] = useState("");
+  const [identityLookup, setIdentityLookup] = useState("");
+  const [accoladeDropdownShow, setAccoladeDropdownShow] = useState(false);
+  const [identityDropdownShow, setIdentityDropdownShow] = useState(false);
+
+  const { data: accoladeResult } = useLookupAccoladeQuery(accoladeLookup, {
+    skip: accoladeLookup.length < 4,
+  });
+  const { data: identityResult } = useLookupIdentityQuery(identityLookup, {
+    skip: identityLookup.length < 4,
+  });
+
+  // Debug logging for search results
+  useEffect(() => {
+    if (accoladeResult) {
+      console.log("Badge search results for '" + accoladeLookup + "':", JSON.stringify(accoladeResult, null, 2));
+    }
+  }, [accoladeResult, accoladeLookup]);
+
+  useEffect(() => {
+    if (identityResult) {
+      console.log("User search results for '" + identityLookup + "':", JSON.stringify(identityResult, null, 2));
+    }
+  }, [identityResult, identityLookup]);
+
+  useEffect(() => {
+    if (isLoading) {
+      dispatch(showLoad());
+    } else {
+      dispatch(hideLoad());
+    }
+  }, [isLoading, dispatch]);
+
+  const handleAccoladeSelect = (accolade) => {
+    console.log("Selected badge:", JSON.stringify(accolade, null, 2));
+    setAccoladeLookup(accolade.name);
+    makeForm((prev) => ({ ...prev, badge_id: accolade.id }));
+    setAccoladeDropdownShow(false);
+  };
+
+  const handleIdentitySelect = (identity) => {
+    console.log("Selected user:", JSON.stringify(identity, null, 2));
+    setIdentityLookup(identity.nickname);
+    makeForm((prev) => ({ ...prev, user: identity.nickname }));
+    setIdentityDropdownShow(false);
+  };
+
+  const handleTask = async () => {
+    try {
+      console.log("Submitting authorization data:", JSON.stringify(form, null, 2));
+      await creationSanction(form).unwrap();
+      dispatch(showBaseNote({ pass: true, data: "Authorization was created successfully" }));
+      makeForm({
+        badge_id: "",
+        user: "",
+      });
+      setAccoladeLookup("");
+      setIdentityLookup("");
+      setAccoladeDropdownShow(false);
+      setIdentityDropdownShow(false);
+    } catch (error) {
+      let expt;
+      switch (error?.status) {
+        case 400:
+          expt = "Verify the requested fields";
+          break;
+        case 401:
+          expt = "Try authenticating before creating";
+          break;
+        case 403:
+          expt = "Ensure permissions are available";
+          break;
+        case 409:
+          expt = "Conflicting with existing authorization";
+          break;
+        case 500:
+          expt = "Attempt creation again later";
+          break;
+        default:
+          expt = "Failed during authorization creation";
+      }
+      dispatch(showBaseNote({ pass: false, data: expt }));
+    }
+  };
+
+  return (
+    <Card className="mb-2">
+      <Card.Body className="ps-0 pe-0 pt-2 pb-0">
+        <Card.Title className="mb-0 ps-2 dataelem">Create authorizations</Card.Title>
+        <Card.Text className="mb-0 ps-2 small">Permit contributors to felicitate fellow participants</Card.Text>
+        <hr className="mt-2 mb-0" />
+        <Row className="mt-0 mb-2 ms-1 me-1 g-2">
+          <Col lg="6">
+            <div className="position-relative">
+              <FloatingLabel controlId="authCreateBadge" label="Badge*">
+                <Form.Control
+                  type="text"
+                  value={accoladeLookup}
+                  onChange={(e) => {
+                    setAccoladeLookup(e.target.value);
+                    setAccoladeDropdownShow(e.target.value.length >= 4);
+                  }}
+                  onFocus={() => accoladeLookup.length >= 4 && setAccoladeDropdownShow(true)}
+                  onBlur={() => setTimeout(() => setAccoladeDropdownShow(false), 150)}
+                  required
+                />
+              </FloatingLabel>
+              {accoladeLookup.length >= 4 &&
+                accoladeResult &&
+                accoladeResult.badges &&
+                accoladeResult.badges.length > 0 &&
+                accoladeDropdownShow && (
+                  <Dropdown.Menu show className="position-absolute w-100 mt-1" style={{ zIndex: 1050 }}>
+                    <Dropdown.Header className="small p-1">Badges</Dropdown.Header>
+                    {accoladeResult.badges.slice(0, 8).map((accolade) => (
+                      <Dropdown.Item
+                        key={accolade.id}
+                        onClick={() => handleAccoladeSelect(accolade)}
+                        className="small d-flex align-items-center p-1"
+                      >
+                        <Image
+                          rounded={true}
+                          src={accolade.image.toString().replace("https://badges.fedoraproject.org", "")}
+                          width="40"
+                          height="40"
+                          className="me-2"
+                        />
+                        <div className="flex-grow-1 overflow-hidden">
+                          <div className="fw-bold text-truncate">{accolade.name}</div>
+                          <div className="small text-muted text-truncate">{accolade.description}</div>
+                        </div>
+                      </Dropdown.Item>
+                    ))}
+                    {accoladeResult.badges.length > 8 && (
+                      <Dropdown.Item disabled className="small text-muted p-1">
+                        +{accoladeResult.badges.length - 8} more badges
+                      </Dropdown.Item>
+                    )}
+                  </Dropdown.Menu>
+                )}
+            </div>
+          </Col>
+          <Col lg="6">
+            <div className="position-relative">
+              <FloatingLabel controlId="authCreateUser" label="User*">
+                <Form.Control
+                  type="text"
+                  value={identityLookup}
+                  onChange={(e) => {
+                    setIdentityLookup(e.target.value);
+                    setIdentityDropdownShow(e.target.value.length >= 4);
+                  }}
+                  onFocus={() => identityLookup.length >= 4 && setIdentityDropdownShow(true)}
+                  onBlur={() => setTimeout(() => setIdentityDropdownShow(false), 150)}
+                  required
+                />
+              </FloatingLabel>
+              {identityLookup.length >= 4 &&
+                identityResult &&
+                identityResult.users &&
+                identityResult.users.length > 0 &&
+                identityDropdownShow && (
+                  <Dropdown.Menu show className="position-absolute w-100 mt-1" style={{ zIndex: 1050 }}>
+                    <Dropdown.Header className="small p-1">Users</Dropdown.Header>
+                    {identityResult.users.slice(0, 8).map((identity) => (
+                      <Dropdown.Item
+                        key={identity.id}
+                        onClick={() => handleIdentitySelect(identity)}
+                        className="small d-flex align-items-center p-1"
+                      >
+                        <Image
+                          rounded={true}
+                          src={portraitProvider(identity.email, 40)}
+                          width="40"
+                          height="40"
+                          className="me-2"
+                        />
+                        <div className="flex-grow-1 overflow-hidden">
+                          <div className="fw-bold text-truncate">{identity.nickname}</div>
+                          <div className="small text-muted text-truncate">#{identity.rank}</div>
+                        </div>
+                      </Dropdown.Item>
+                    ))}
+                    {identityResult.users.length > 8 && (
+                      <Dropdown.Item disabled className="small text-muted p-1">
+                        +{identityResult.users.length - 8} more users
+                      </Dropdown.Item>
+                    )}
+                  </Dropdown.Menu>
+                )}
+            </div>
+          </Col>
+        </Row>
+        <hr className="mt-2 mb-0" />
+        <Row className="mt-0 mb-0 ms-1 me-1 g-2">
+          <Col lg="12">
+            <Button
+              variant="outline-secondary"
+              className="d-grid w-100 mb-2"
+              size="sm"
+              onClick={handleTask}
+              disabled={!form.badge_id.trim() || !form.user.trim() || isLoading}
+            >
+              {isLoading ? "Creating..." : "Create"}
+            </Button>
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/frontend/src/features/call.js
+++ b/frontend/src/features/call.js
@@ -16,6 +16,7 @@ export const callUnit = createApi({
     "AccoladeSearch",
     "IdentitySearch",
     "QRInvite",
+    "Sanction",
   ],
   endpoints: (builder) => ({
     retrieveIdentity: builder.query({
@@ -187,6 +188,18 @@ export const callUnit = createApi({
         "Discover",
       ],
     }),
+    creationSanction: builder.mutation({
+      query: (sanctionData) => ({
+        url: "../api/admin/authorization",
+        method: "POST",
+        body: sanctionData,
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+      invalidatesTags: ["Sanction"], // Reload Sanction on creation
+    }),
   }),
 });
 
@@ -208,6 +221,7 @@ export const {
   useCreationQRInviteMutation,
   useDeletionQRInviteMutation,
   useUpdationAccoladeMutation,
+  useCreationSanctionMutation,
 } = callUnit;
 
 export default callUnit.reducer;

--- a/frontend/src/routes/governor.jsx
+++ b/frontend/src/routes/governor.jsx
@@ -8,6 +8,7 @@ import { Link, useNavigate } from "react-router";
 import BaseNote from "../components/basenote.jsx";
 import AssertionCreationForm from "../crud/assertions/create.jsx";
 import AssertionUpdateForm from "../crud/assertions/delete.jsx";
+import AuthorizationCreationForm from "../crud/authorizations/create.jsx";
 import BadgeCreationForm from "../crud/badges/create.jsx";
 import BadgeUpdateForm from "../crud/badges/update.jsx";
 import InvitationCreationForm from "../crud/invitations/create.jsx";
@@ -90,29 +91,7 @@ export default function Governor() {
               <Icon path={mdiCrown} size={1} />
             </ListGroup.Item>
           </ListGroup>
-          <Card className="mb-2">
-            <Card.Body className="ps-0 pe-0 pt-2 pb-0">
-              <Card.Title className="mb-0 ps-2 dataelem">Create authorizations</Card.Title>
-              <Card.Text className="mb-0 ps-2 small">Permit contributors to felicitate fellow participants</Card.Text>
-              <hr className="mt-2 mb-0" />
-              <Row className="mt-0 mb-2 ms-1 me-1 g-2">
-                <Col lg="6">
-                  <FloatingLabel controlId="authCreateAcco" label="Badge">
-                    <Form.Control type="text" />
-                  </FloatingLabel>
-                </Col>
-                <Col lg="6">
-                  <FloatingLabel controlId="authCreateUser" label="User">
-                    <Form.Control type="text" />
-                  </FloatingLabel>
-                </Col>
-              </Row>
-              <hr className="mt-2 mb-0" />
-              <Button as={Link} to="" variant="outline-secondary" className="d-grid m-2" size="sm">
-                Create
-              </Button>
-            </Card.Body>
-          </Card>
+          <AuthorizationCreationForm />
           <Card className="mb-2">
             <Card.Body className="ps-0 pe-0 pt-2 pb-0">
               <Card.Title className="mb-0 ps-2 dataelem">Remove authorizations</Card.Title>

--- a/tahrir/endpoints/admin/authorizations.py
+++ b/tahrir/endpoints/admin/authorizations.py
@@ -1,0 +1,38 @@
+from flask import abort, g, jsonify, request
+
+from ...app import csrf, oidc
+from ...utils.user import require_admin
+from . import blueprint as bp
+
+
+@bp.route("/api/admin/authorization", methods=["POST"])
+@csrf.exempt
+@oidc.require_login
+@require_admin
+def add_authorization():
+    """Endpoint to add authorization and allow someone to admin a certain badge"""
+
+    data = request.get_json()
+    if not data:
+        return abort(400, "No details provided")
+
+    required_fields = ["badge_id", "user"]
+    for field in required_fields:
+        if not data.get(field):
+            return abort(400, f"No detail provided for {field!r}")
+
+    # ONE SHOULD NOT FEEL THE NEED OF USING THE EMAIL ADDRESS HERE
+    # THIS WORKAROUND IS TEMPORARY AND TAHRIR-API WOULD BE CHANGED TO ACCEPT JUST USERNAME
+    result = g.tahrirdb.add_authorization(
+        badge_id=data.get(required_fields[0]),
+        person_email=data.get(required_fields[1]) + "@fedoraproject.org",
+    )
+
+    if not result:
+        return abort(400, "Failed to add authorization")
+
+    return jsonify(
+        {
+            "message": f"Badge {data.get(required_fields[0])!r} authorized to {data.get(required_fields[1])!r}"
+        }
+    ), 201

--- a/tahrir/templates/test.html
+++ b/tahrir/templates/test.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+<head><meta name="csrf-token" content="{{ csrf_token }}"></head>
+<body>
+<button onclick="createBadge()">Create Test Badge</button>
+<button onclick="deleteBadge()">Delete Test Badge</button>
+<button onclick="createAssertion()">Create Test Assertion</button>
+<button onclick="addUser()">Create Test User</button>
+<button onclick="createInvitation()">Create Test Invitation</button>
+<button onclick="deleteInvitation()">Delete Test Invitation</button>
+
+<script>
+function createBadge() {
+    fetch('/api/admin/badges', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+            "name": "baccha",
+            "image": "https://example.com/test-badge.png",
+            "description": "Test badge baccha",
+            "criteria": "Test criteria",
+            "issuer_id": 1,
+            "tags": "test"
+        })
+    })
+    .then(r => r.text())
+    .then(d => {
+        console.log('Response:', d);
+        alert('Response: ' + d.substring(0, 200));
+    })
+    .catch(e => alert('Error: ' + e));
+}
+
+function deleteBadge() {
+    const badgeId = 'baccha'; // Using the same badge ID from create function
+
+    fetch(`/api/admin/badges/${badgeId}`, {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        credentials: 'include'
+    })
+    .then(r => r.text())
+    .then(d => {
+        console.log('Response:', d);
+        alert('Response: ' + d.substring(0, 200));
+    })
+    .catch(e => alert('Error: ' + e));
+}
+
+function createAssertion() {
+    fetch('/api/admin/assertions', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+            "badge_id": "baccha",
+            "person_email": "sdglitched@fedoraproject.org",
+            "issued_for": "Testing assertion creation"
+        })
+    })
+    .then(r => r.text())
+    .then(d => {
+        console.log('Response:', d);
+        alert('Response: ' + d.substring(0, 200));
+    })
+    .catch(e => alert('Error: ' + e));
+}
+
+function addUser() {
+    fetch('/api/admin/users', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+            "email": "baccha@fedoraproject.com",
+            "nickname": "baccha",
+            "website": "Test user baccha website",
+            "bio": "Test user bio",
+            "avatar": "Test user avatar",
+        })
+    })
+    .then(r => r.text())
+    .then(d => {
+        console.log('Response:', d);
+        alert('Response: ' + d.substring(0, 200));
+    })
+    .catch(e => alert('Error: ' + e));
+}
+
+function createInvitation() {
+    const now = Math.floor(Date.now() / 1000);
+    const expiresIn7Days = now + (7 * 24 * 60 * 60);
+
+    fetch('/api/admin/invitations', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+            "badge_id": "dancing-with-toshio",
+            "created_on": now,
+            "expires_on": expiresIn7Days,
+            "issuer_email": "aaronhale"
+        })
+    })
+    .then(r => r.text())
+    .then(d => {
+        console.log('Response:', d);
+        alert('Response: ' + d.substring(0, 200));
+    })
+    .catch(e => alert('Error: ' + e));
+}
+
+function deleteInvitation() {
+    const invitationId = prompt("Enter invitation ID to delete:");
+    if (!invitationId) return;
+
+    fetch('/api/admin/invitations', {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+            "invitation_id": invitationId
+        })
+    })
+    .then(r => r.text())
+    .then(d => {
+        console.log('Response:', d);
+        alert('Response: ' + d.substring(0, 200));
+    })
+    .catch(e => alert('Error: ' + e));
+}
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds a POST endpoint for badge authorization management, allowing administrators to grant users permission to administer specific badges.

## Key changes:
Added new POST endpoint for badge authorization management

## Endpoints added:

POST `/api/admin/authorization` - add authorization and allow someone to admin a certain badge

Note:
This PR does not include DELETE endpoint for removing authorizations as it's not yet available in `tahrir-api`. [PR](https://github.com/fedora-infra/tahrir-api/pull/233) needs to be merged and released.
<img width="1920" height="347" alt="Screenshot From 2025-11-23 19-57-47" src="https://github.com/user-attachments/assets/85579fa2-ccc5-4929-8d2e-af3924e740c4" />
<img width="592" height="243" alt="Screenshot From 2025-11-23 19-58-07" src="https://github.com/user-attachments/assets/4d691d8f-9c79-4b6e-830c-a63e9d07c190" />
@gridhead, thank you for reviewing this PR and let me know if `GET` and `UPDATE` endpoints are needed or not. 