### PR TITLE
Enable username navigation to user profile

### DIFF
--- a/frontend/src/components/navigate.jsx
+++ b/frontend/src/components/navigate.jsx
@@ -106,7 +106,7 @@ export default function Navigate() {
                 align="end"
                 className="p-0"
               >
-                <NavDropdown.Item className="small d-flex align-items-center p-1" disabled>
+                <NavDropdown.Item as={Link} to={`/identity/${user.preferred_username}`} className="small d-flex align-items-center p-1">
                   <Icon className="me-1" size={0.75} path={mdiAccountCircle} />
                   {user.preferred_username}
                 </NavDropdown.Item>


### PR DESCRIPTION
## Summary
- Enable navigation from username in navbar to user identity page

## Changes
- Remove `disabled` prop from username NavDropdown.Item
- Add Link component with routing to `/identity/${user.preferred_username}`

I was not able to successfully test it as OIDC sign-in was redirecting to `badges.gridhead.net`. I tested it by adding a similar `NavDropdown.Item` to work without sign-in.

<img width="1622" height="152" alt="image" src="https://github.com/user-attachments/assets/5b8e4cc1-8d87-498a-8dc8-93bfada0cc50" />

@gridhead, please review the changes and let me know if any other change is needed.

P.S. I'm kinda new to REACT, so let me know if I made some unconventional change.