### PR TITLE
Facilitate navigating back to the homepage after logout

### DIFF
--- a/frontend/src/components/navigate.jsx
+++ b/frontend/src/components/navigate.jsx
@@ -11,7 +11,7 @@ import {
 import Icon from "@mdi/react";
 import { Container, Form, Image, Navbar, NavDropdown } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 
 import { userManager } from "../config/oidc.js";
 import { wipeUserData } from "../features/auth.js";
@@ -21,6 +21,7 @@ import Discover from "./discover.jsx";
 
 export default function Navigate() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const mode = useSelector((data) => data.area.mode);
   const vibe = useSelector((data) => data.area.vibe);
   const user = useSelector((data) => data.auth.user);
@@ -33,6 +34,7 @@ export default function Navigate() {
   const handleLogout = async () => {
     await userManager.removeUser();
     dispatch(wipeUserData());
+    navigate("/");
   };
 
   return (


### PR DESCRIPTION
Facilitate navigating back to the homepage after logout.

If the logged-in user is in the administrator page (i.e. `/governor/` endpoint) and attempts to log out from there, they were previously thrown the `403 Forbidden` error as they would still be on the `/governor/` endpoint but would no longer have access to it as they had logged out. With the introduction of this change, they would be automatically navigated back to the homepage after they have logged out, and hence, they will not witness the unintended `403 Forbidden` error page. 
