### PR TITLE
Add PUT endpoint for updating for USER relation and integrate it with the frontend

### DIFF
--- a/frontend/src/crud/badges/create.jsx
+++ b/frontend/src/crud/badges/create.jsx
@@ -80,6 +80,7 @@ export default function BadgeCreationForm() {
                 type="text"
                 value={form.name}
                 onChange={(e) => handleFormChange("name", e.target.value)}
+                placeholder="Name"
                 autoComplete="off"
                 required
               />
@@ -91,28 +92,31 @@ export default function BadgeCreationForm() {
                 type="text"
                 value={form.description}
                 onChange={(e) => handleFormChange("description", e.target.value)}
+                placeholder="Description"
                 autoComplete="off"
                 required
               />
             </FloatingLabel>
           </Col>
           <Col lg="6">
-            <FloatingLabel controlId="accoCreateShot" label="Image">
+            <FloatingLabel controlId="accoCreateShot" label="Image URL">
               <Form.Control
                 type="url"
                 value={form.image}
                 onChange={(e) => handleFormChange("image", e.target.value)}
+                placeholder="Image URL"
                 autoComplete="off"
                 required
               />
             </FloatingLabel>
           </Col>
           <Col lg="6">
-            <FloatingLabel controlId="accoCreateCrit" label="Criteria">
+            <FloatingLabel controlId="accoCreateCrit" label="Criteria URL">
               <Form.Control
                 type="text"
                 value={form.criteria}
                 onChange={(e) => handleFormChange("criteria", e.target.value)}
+                placeholder="Criteria URL"
                 autoComplete="off"
                 required
               />
@@ -124,11 +128,12 @@ export default function BadgeCreationForm() {
             </FloatingLabel>
           </Col>
           <Col lg="6">
-            <FloatingLabel controlId="accoCreateTags" label="Tags">
+            <FloatingLabel controlId="accoCreateTags" label="Comma Separated Tags">
               <Form.Control
                 type="text"
                 value={form.tags}
                 onChange={(e) => handleFormChange("tags", e.target.value)}
+                placeholder="Comma Separated Tags"
                 autoComplete="off"
               />
             </FloatingLabel>

--- a/frontend/src/crud/badges/update.jsx
+++ b/frontend/src/crud/badges/update.jsx
@@ -12,7 +12,7 @@ export default function BadgeUpdateForm() {
   const { slugdata: accolade } = useParams();
   const [updationAccolade, { isLoading: isUpdating }] = useUpdationAccoladeMutation();
 
-  const [form, setForm] = useState({
+  const [form, makeForm] = useState({
     name: "",
     description: "",
     image: "",
@@ -47,7 +47,7 @@ export default function BadgeUpdateForm() {
 
   useEffect(() => {
     if (badge) {
-      setForm({
+      makeForm({
         name: badge.name || "",
         description: badge.description || "",
         image: badge.image || "",
@@ -61,11 +61,11 @@ export default function BadgeUpdateForm() {
   }, [badge]);
 
   const handleFormChange = (field, value) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
+    makeForm((prev) => ({ ...prev, [field]: value }));
   };
 
   const handleAccoladeSelect = (accolade) => {
-    setForm({
+    makeForm({
       name: accolade.name || "",
       description: accolade.description || "",
       image: accolade.image || "",
@@ -94,27 +94,27 @@ export default function BadgeUpdateForm() {
       };
       const updateData = Object.fromEntries(Object.entries(filldata).filter(([, value]) => value !== ""));
       await updationAccolade({ accolade: form.id, filldata: updateData }).unwrap();
-      dispatch(showBaseNote({ pass: true, data: "Badge updated successfully" }));
+      dispatch(showBaseNote({ pass: true, data: "Badge was updated successfully" }));
     } catch (error) {
       let expt;
       switch (error?.status) {
         case 400:
-          expt = "Invalid field names or values provided";
+          expt = "Verify the requested fields";
           break;
         case 401:
-          expt = "Authentication required";
+          expt = "Try authenticating before updating";
           break;
         case 403:
-          expt = "Admin permissions required";
+          expt = "Ensure permissions are available";
           break;
         case 404:
           expt = "Badge not found";
           break;
         case 500:
-          expt = "Server error - try again later";
+          expt = "Attempt update again later";
           break;
         default:
-          expt = "Failed to update badge";
+          expt = "Failed during badge update";
       }
       dispatch(showBaseNote({ pass: false, data: expt }));
     }
@@ -150,9 +150,21 @@ export default function BadgeUpdateForm() {
                     setAccoladeLookup(e.target.value);
                     handleFormChange("name", e.target.value);
                     setAccoladeDropdownShow(e.target.value.length >= 4);
+                    if (e.target.value === "") {
+                      makeForm({
+                        name: "",
+                        description: "",
+                        image: "",
+                        criteria: "",
+                        tags: "",
+                        created_on: "",
+                        id: "",
+                      });
+                    }
                   }}
                   onFocus={() => accoladeLookup.length >= 4 && setAccoladeDropdownShow(true)}
                   onBlur={() => setTimeout(() => setAccoladeDropdownShow(false), 150)}
+                  placeholder="Name"
                   autoComplete="off"
                 />
               </FloatingLabel>
@@ -197,45 +209,45 @@ export default function BadgeUpdateForm() {
                 type="text"
                 value={form.description}
                 onChange={(e) => handleFormChange("description", e.target.value)}
-                placeholder="Badge description"
+                placeholder="Description"
                 autoComplete="off"
               />
             </FloatingLabel>
           </Col>
           <Col lg="6">
-            <FloatingLabel controlId="accoUpdateShot" label="Image">
+            <FloatingLabel controlId="accoUpdateShot" label="Image URL">
               <Form.Control
                 type="url"
                 value={form.image}
                 onChange={(e) => handleFormChange("image", e.target.value)}
-                placeholder="Badge image URL"
+                placeholder="Image URL"
                 autoComplete="off"
               />
             </FloatingLabel>
           </Col>
           <Col lg="6">
-            <FloatingLabel controlId="accoUpdateCrit" label="Criteria">
+            <FloatingLabel controlId="accoUpdateCrit" label="Criteria URL">
               <Form.Control
                 type="url"
                 value={form.criteria}
                 onChange={(e) => handleFormChange("criteria", e.target.value)}
-                placeholder="Badge criteria URL"
+                placeholder="Criteria URL"
                 autoComplete="off"
               />
             </FloatingLabel>
           </Col>
           <Col lg="6">
             <FloatingLabel controlId="accoUpdateAuth" label="Issuer">
-              <Form.Control type="text" value="Fedora Project" disabled />
+              <Form.Control type="text" value="Fedora Project" readOnly />
             </FloatingLabel>
           </Col>
           <Col lg="6">
-            <FloatingLabel controlId="accoUpdateTags" label="Tags">
+            <FloatingLabel controlId="accoUpdateTags" label="Comma Separated Tags">
               <Form.Control
                 type="text"
                 value={form.tags}
                 onChange={(e) => handleFormChange("tags", e.target.value)}
-                placeholder="Badge tags (comma-separated)"
+                placeholder="Comma Separated Tags"
                 autoComplete="off"
               />
             </FloatingLabel>

--- a/frontend/src/crud/users/create.jsx
+++ b/frontend/src/crud/users/create.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { Button, Card, Col, FloatingLabel, Form, Row } from "react-bootstrap";
+import { useDispatch } from "react-redux";
+
+import { useCreationIdentityMutation } from "../../features/call.js";
+import { hideLoad, showBaseNote, showLoad } from "../../features/part.js";
+
+export default function UserCreationForm() {
+  const dispatch = useDispatch();
+  const [creationIdentity, { isLoading }] = useCreationIdentityMutation();
+
+  const [form, makeForm] = useState({
+    nickname: "",
+    email: "",
+    website: "",
+    bio: "",
+    avatar: "",
+  });
+
+  useEffect(() => {
+    if (isLoading) {
+      dispatch(showLoad());
+    } else {
+      dispatch(hideLoad());
+    }
+  }, [isLoading, dispatch]);
+
+  const handleFormChange = (field, value) => {
+    makeForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleTask = async () => {
+    try {
+      await creationIdentity(form).unwrap();
+      dispatch(showBaseNote({ pass: true, data: "User was created successfully" }));
+      makeForm({
+        nickname: "",
+        email: "",
+        website: "",
+        bio: "",
+        avatar: "",
+      });
+    } catch (error) {
+      let expt;
+      switch (error?.status) {
+        case 400:
+          expt = "Verify the requested fields";
+          break;
+        case 401:
+          expt = "Try authenticating before creating";
+          break;
+        case 403:
+          expt = "Ensure permissions are available";
+          break;
+        case 409:
+          expt = "Conflicting with existing user";
+          break;
+        case 500:
+          expt = "Attempt creation again later";
+          break;
+        default:
+          expt = "Failed during user creation";
+      }
+      dispatch(showBaseNote({ pass: false, data: expt }));
+    }
+  };
+
+  return (
+    <Card className="mb-2">
+      <Card.Body className="ps-0 pe-0 pt-2 pb-0">
+        <Card.Title className="mb-0 ps-2 dataelem">Create users</Card.Title>
+        <Card.Text className="mb-0 ps-2 small">Create accounts that will obtain felicitation</Card.Text>
+        <hr className="mt-2 mb-0" />
+        <Row className="mt-0 mb-2 ms-1 me-1 g-2">
+          <Col lg="6">
+            <FloatingLabel controlId="userCreateName" label="Nickname">
+              <Form.Control
+                type="text"
+                value={form.nickname}
+                onChange={(e) => handleFormChange("nickname", e.target.value)}
+                autoComplete="off"
+                required
+              />
+            </FloatingLabel>
+          </Col>
+          <Col lg="6">
+            <FloatingLabel controlId="userCreateMail" label="Email">
+              <Form.Control
+                type="email"
+                value={form.email}
+                onChange={(e) => handleFormChange("email", e.target.value)}
+                autoComplete="off"
+                required
+              />
+            </FloatingLabel>
+          </Col>
+          <Col lg="6">
+            <FloatingLabel controlId="userCreateWebsite" label="Website">
+              <Form.Control
+                type="text"
+                value={form.website}
+                onChange={(e) => handleFormChange("website", e.target.value)}
+                autoComplete="off"
+              />
+            </FloatingLabel>
+          </Col>
+          <Col lg="6">
+            <FloatingLabel controlId="userCreateAvatar" label="Avatar">
+              <Form.Control
+                type="text"
+                value={form.avatar}
+                onChange={(e) => handleFormChange("avatar", e.target.value)}
+                autoComplete="off"
+              />
+            </FloatingLabel>
+          </Col>
+          <Col lg="12">
+            <FloatingLabel controlId="userCreateBio" label="Bio">
+              <Form.Control
+                type="text"
+                value={form.bio}
+                onChange={(e) => handleFormChange("bio", e.target.value)}
+                autoComplete="off"
+              />
+            </FloatingLabel>
+          </Col>
+        </Row>
+        <hr className="mt-2 mb-0" />
+        <Row className="mt-0 mb-0 ms-1 me-1 g-2">
+          <Col lg="12">
+            <Button
+              variant="outline-secondary"
+              className="d-grid w-100 mb-2"
+              size="sm"
+              onClick={handleTask}
+              disabled={
+                !form.nickname.trim() ||
+                !form.email.trim() ||
+                isLoading
+              }
+            >
+              {isLoading ? "Creating..." : "Create"}
+            </Button>
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/frontend/src/crud/users/create.jsx
+++ b/frontend/src/crud/users/create.jsx
@@ -79,6 +79,7 @@ export default function UserCreationForm() {
                 value={form.nickname}
                 onChange={(e) => handleFormChange("nickname", e.target.value)}
                 autoComplete="off"
+                placeholder="Nickname"
                 required
               />
             </FloatingLabel>
@@ -90,6 +91,7 @@ export default function UserCreationForm() {
                 value={form.email}
                 onChange={(e) => handleFormChange("email", e.target.value)}
                 autoComplete="off"
+                placeholder="Email"
                 required
               />
             </FloatingLabel>
@@ -100,26 +102,29 @@ export default function UserCreationForm() {
                 type="text"
                 value={form.website}
                 onChange={(e) => handleFormChange("website", e.target.value)}
+                placeholder="Website"
                 autoComplete="off"
               />
             </FloatingLabel>
           </Col>
           <Col lg="6">
-            <FloatingLabel controlId="userCreateAvatar" label="Avatar">
+            <FloatingLabel controlId="userCreateAvatar" label="Avatar URL">
               <Form.Control
                 type="text"
                 value={form.avatar}
                 onChange={(e) => handleFormChange("avatar", e.target.value)}
+                placeholder="Avatar URL"
                 autoComplete="off"
               />
             </FloatingLabel>
           </Col>
           <Col lg="12">
-            <FloatingLabel controlId="userCreateBio" label="Bio">
+            <FloatingLabel controlId="userCreateBio" label="Biography">
               <Form.Control
                 type="text"
                 value={form.bio}
                 onChange={(e) => handleFormChange("bio", e.target.value)}
+                placeholder="Biography"
                 autoComplete="off"
               />
             </FloatingLabel>
@@ -133,11 +138,7 @@ export default function UserCreationForm() {
               className="d-grid w-100 mb-2"
               size="sm"
               onClick={handleTask}
-              disabled={
-                !form.nickname.trim() ||
-                !form.email.trim() ||
-                isLoading
-              }
+              disabled={!form.nickname.trim() || !form.email.trim() || isLoading}
             >
               {isLoading ? "Creating..." : "Create"}
             </Button>

--- a/frontend/src/crud/users/update.jsx
+++ b/frontend/src/crud/users/update.jsx
@@ -1,0 +1,298 @@
+import { useEffect, useState } from "react";
+import { Button, Card, Col, Dropdown, FloatingLabel, Form, Image, Row } from "react-bootstrap";
+import { useDispatch } from "react-redux";
+
+import { useLookupIdentityQuery, useToggleIdentityOptOutMutation, useUpdationIdentityMutation } from "../../features/call.js";
+import { hideLoad, showBaseNote, showLoad } from "../../features/part.js";
+import { formatTime, portraitProvider } from "../../features/util.js";
+
+export default function UserUpdateForm() {
+  const dispatch = useDispatch();
+  const [updationIdentity, { isLoading: isUpdating }] = useUpdationIdentityMutation();
+  const [toggleOptOut, { isLoading: isToggling }] = useToggleIdentityOptOutMutation();
+
+  const [form, makeForm] = useState({
+    nickname: "",
+    email: "",
+    website: "",
+    bio: "",
+    avatar: "",
+    id: "",
+    created_on: "",
+    last_login: "",
+    opt_out: false,
+  });
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [userDropdownShow, setUserDropdownShow] = useState(false);
+
+  const { data: searchResults, isLoading: isSearching } = useLookupIdentityQuery(searchTerm, {
+    skip: searchTerm.length < 4,
+  });
+
+  useEffect(() => {
+    if (isUpdating || isSearching || isToggling) {
+      dispatch(showLoad());
+    } else {
+      dispatch(hideLoad());
+    }
+  }, [isUpdating, isSearching, isToggling, dispatch]);
+
+  const handleFormChange = (field, value) => {
+    makeForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleUserSelect = (user) => {
+    makeForm({
+      nickname: user.nickname || "",
+      email: user.email || "",
+      website: user.website || "",
+      bio: user.bio || "",
+      avatar: user.email || "",
+      id: user.id || "",
+      created_on: user.created_on || "",
+      last_login: user.last_login || "",
+      opt_out: user.opt_out || false,
+    });
+    setSearchTerm(user.nickname || "");
+    setUserDropdownShow(false);
+  };
+
+  const handleTask = async () => {
+    if (!form.id) {
+      dispatch(showBaseNote({ pass: false, data: "No user selected" }));
+      return;
+    }
+
+    try {
+      const filldata = {
+        website: form.website.trim(),
+        bio: form.bio.trim(),
+        avatar: form.avatar.trim(),
+      };
+      const updateData = Object.fromEntries(Object.entries(filldata).filter(([, value]) => value !== ""));
+      await updationIdentity({
+        user_id: form.nickname,
+        filldata: updateData,
+      }).unwrap();
+      dispatch(showBaseNote({ pass: true, data: "User was updated successfully" }));
+    } catch (error) {
+      let expt;
+      switch (error?.status) {
+        case 400:
+          expt = "Verify the requested fields";
+          break;
+        case 401:
+          expt = "Try authenticating before updating";
+          break;
+        case 403:
+          expt = "Ensure permissions are available";
+          break;
+        case 404:
+          expt = "User not found";
+          break;
+        case 500:
+          expt = "Attempt update again later";
+          break;
+        default:
+          expt = "Failed during user update";
+      }
+      dispatch(showBaseNote({ pass: false, data: expt }));
+    }
+  };
+
+  const handleToggleOptOut = async () => {
+    if (!form.id) {
+      dispatch(showBaseNote({ pass: false, data: "No user selected" }));
+      return;
+    }
+
+    try {
+      const newOptOutStatus = !form.opt_out;
+      await toggleOptOut({
+        user_id: form.nickname,
+        opt_out: newOptOutStatus,
+      }).unwrap();
+
+      makeForm((prev) => ({ ...prev, opt_out: newOptOutStatus }));
+
+      const action = newOptOutStatus ? "deactivated" : "activated";
+      dispatch(showBaseNote({ pass: true, data: `User ${action} successfully` }));
+    } catch (error) {
+      let expt;
+      switch (error?.status) {
+        case 400:
+          expt = "Invalid request";
+          break;
+        case 401:
+          expt = "Authentication required";
+          break;
+        case 403:
+          expt = "Admin permissions required";
+          break;
+        case 404:
+          expt = "User not found";
+          break;
+        case 500:
+          expt = "Server error - try again later";
+          break;
+        default:
+          expt = "Failed to toggle user status";
+      }
+      dispatch(showBaseNote({ pass: false, data: expt }));
+    }
+  };
+
+  return (
+    <Card className="mb-2">
+      <Card.Body className="ps-0 pe-0 pt-2 pb-0">
+        <Card.Title className="mb-0 ps-2 dataelem">Update users</Card.Title>
+        <Card.Text className="mb-0 ps-2 small">Update accounts that will obtain felicitation</Card.Text>
+        <hr className="mt-2 mb-0" />
+        <Row className="mt-0 mb-2 ms-1 me-1 g-2">
+          <Col lg="6">
+            <div className="position-relative">
+              <FloatingLabel controlId="userUpdateName" label="Nickname">
+                <Form.Control
+                  type="text"
+                  value={searchTerm}
+                  onChange={(e) => {
+                    setSearchTerm(e.target.value);
+                    setUserDropdownShow(e.target.value.length >= 4);
+                    if (e.target.value === "") {
+                      makeForm({
+                        nickname: "",
+                        email: "",
+                        website: "",
+                        bio: "",
+                        avatar: "",
+                        id: "",
+                        created_on: "",
+                        last_login: "",
+                        opt_out: false,
+                      });
+                    }
+                  }}
+                  onFocus={() => searchTerm.length >= 4 && setUserDropdownShow(true)}
+                  onBlur={() => setTimeout(() => setUserDropdownShow(false), 150)}
+                  autoComplete="off"
+                />
+              </FloatingLabel>
+              {searchTerm.length >= 2 &&
+                searchResults &&
+                searchResults.users &&
+                searchResults.users.length > 0 &&
+                userDropdownShow && (
+                  <Dropdown.Menu show className="position-absolute w-100 mt-1" style={{ zIndex: 1050 }}>
+                    <Dropdown.Header className="small p-1">Users</Dropdown.Header>
+                    {searchResults.users.slice(0, 8).map((user) => (
+                      <Dropdown.Item
+                        key={user.id}
+                        onClick={() => handleUserSelect(user)}
+                        className="small d-flex align-items-center p-1"
+                      >
+                        <Image
+                          rounded={true}
+                          src={portraitProvider(user.email, 40)}
+                          width="40"
+                          height="40"
+                          className="me-2"
+                        />
+                        <div className="flex-grow-1 overflow-hidden">
+                          <div className="fw-bold text-truncate">{user.nickname}</div>
+                          <div className="small text-muted text-truncate">{user.email}</div>
+                        </div>
+                      </Dropdown.Item>
+                    ))}
+                    {searchResults.users.length > 8 && (
+                      <Dropdown.Item disabled className="small text-muted p-1">
+                        +{searchResults.users.length - 8} more users
+                      </Dropdown.Item>
+                    )}
+                  </Dropdown.Menu>
+                )}
+            </div>
+          </Col>
+          <Col lg="6">
+            <FloatingLabel controlId="userUpdateMail" label="Email">
+              <Form.Control
+                type="email"
+                value={form.email}
+                autoComplete="off"
+                readOnly
+              />
+            </FloatingLabel>
+          </Col>
+          <Col lg="6">
+            <FloatingLabel controlId="userUpdateSite" label="Website">
+              <Form.Control
+                type="url"
+                value={form.website}
+                onChange={(e) => handleFormChange("website", e.target.value)}
+                autoComplete="off"
+              />
+            </FloatingLabel>
+          </Col>
+          <Col lg="6">
+            <FloatingLabel controlId="userUpdateAvatar" label="Avatar URL">
+              <Form.Control
+                type="url"
+                value={form.avatar}
+                onChange={(e) => handleFormChange("avatar", e.target.value)}
+                autoComplete="off"
+              />
+            </FloatingLabel>
+          </Col>
+          <Col lg="12">
+            <FloatingLabel controlId="userUpdateInfo" label="Bio">
+              <Form.Control
+                type="text"
+                value={form.bio}
+                onChange={(e) => handleFormChange("bio", e.target.value)}
+                autoComplete="off"
+              />
+            </FloatingLabel>
+          </Col>
+        </Row>
+        <hr className="mt-2 mb-2" />
+        <p className="small ps-2 pe-2 m-0">
+          Last seen on{" "}
+          <span className="fw-bold">
+            {form.last_login ? formatTime(form.last_login) : "Never"}
+          </span>
+        </p>
+        <p className="small ps-2 pe-2 m-0">
+          Account created on{" "}
+          <span className="fw-bold">
+            {form.created_on ? formatTime(form.created_on) : "Unknown"}
+          </span>
+        </p>
+        <hr className="mt-2 mb-0" />
+        <Row className="mt-0 mb-0 ms-1 me-1 g-2">
+          <Col lg="6">
+            <Button
+              variant="outline-secondary"
+              className="d-grid"
+              size="sm"
+              onClick={handleTask}
+              disabled={!form.id || isUpdating}
+            >
+              {isUpdating ? "Updating..." : "Update"}
+            </Button>
+          </Col>
+          <Col lg="6">
+            <Button
+              variant="outline-secondary"
+              className="d-grid mb-2"
+              size="sm"
+              onClick={handleToggleOptOut}
+              disabled={!form.id || isToggling}
+            >
+              {isToggling ? "Processing..." : form.opt_out ? "Activate" : "Deactivate"}
+            </Button>
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/frontend/src/crud/users/update.jsx
+++ b/frontend/src/crud/users/update.jsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from "react";
 import { Button, Card, Col, Dropdown, FloatingLabel, Form, Image, Row } from "react-bootstrap";
 import { useDispatch } from "react-redux";
 
-import { useLookupIdentityQuery, useToggleIdentityOptOutMutation, useUpdationIdentityMutation } from "../../features/call.js";
+import {
+  useLookupIdentityQuery,
+  useToggleIdentityOptOutMutation,
+  useUpdationIdentityMutation,
+} from "../../features/call.js";
 import { hideLoad, showBaseNote, showLoad } from "../../features/part.js";
 import { formatTime, portraitProvider } from "../../features/util.js";
 
@@ -23,20 +27,20 @@ export default function UserUpdateForm() {
     opt_out: false,
   });
 
-  const [searchTerm, setSearchTerm] = useState("");
+  const [userLookup, setUserLookup] = useState("");
   const [userDropdownShow, setUserDropdownShow] = useState(false);
 
-  const { data: searchResults, isLoading: isSearching } = useLookupIdentityQuery(searchTerm, {
-    skip: searchTerm.length < 4,
+  const { data: searchResults } = useLookupIdentityQuery(userLookup, {
+    skip: userLookup.length < 4,
   });
 
   useEffect(() => {
-    if (isUpdating || isSearching || isToggling) {
+    if (isUpdating || isToggling) {
       dispatch(showLoad());
     } else {
       dispatch(hideLoad());
     }
-  }, [isUpdating, isSearching, isToggling, dispatch]);
+  }, [isUpdating, isToggling, dispatch]);
 
   const handleFormChange = (field, value) => {
     makeForm((prev) => ({ ...prev, [field]: value }));
@@ -54,11 +58,11 @@ export default function UserUpdateForm() {
       last_login: user.last_login || "",
       opt_out: user.opt_out || false,
     });
-    setSearchTerm(user.nickname || "");
+    setUserLookup(user.nickname || "");
     setUserDropdownShow(false);
   };
 
-  const handleTask = async () => {
+  const handleUpdate = async () => {
     if (!form.id) {
       dispatch(showBaseNote({ pass: false, data: "No user selected" }));
       return;
@@ -113,31 +117,29 @@ export default function UserUpdateForm() {
         user_id: form.nickname,
         opt_out: newOptOutStatus,
       }).unwrap();
-
       makeForm((prev) => ({ ...prev, opt_out: newOptOutStatus }));
-
       const action = newOptOutStatus ? "deactivated" : "activated";
       dispatch(showBaseNote({ pass: true, data: `User ${action} successfully` }));
     } catch (error) {
       let expt;
       switch (error?.status) {
         case 400:
-          expt = "Invalid request";
+          expt = "Verify the requested fields";
           break;
         case 401:
-          expt = "Authentication required";
+          expt = "Try authenticating before toggling";
           break;
         case 403:
-          expt = "Admin permissions required";
+          expt = "Ensure permissions are available";
           break;
         case 404:
           expt = "User not found";
           break;
         case 500:
-          expt = "Server error - try again later";
+          expt = "Attempt toggling again later";
           break;
         default:
-          expt = "Failed to toggle user status";
+          expt = "Failed during user toggling";
       }
       dispatch(showBaseNote({ pass: false, data: expt }));
     }
@@ -155,9 +157,9 @@ export default function UserUpdateForm() {
               <FloatingLabel controlId="userUpdateName" label="Nickname">
                 <Form.Control
                   type="text"
-                  value={searchTerm}
+                  value={userLookup}
                   onChange={(e) => {
-                    setSearchTerm(e.target.value);
+                    setUserLookup(e.target.value);
                     setUserDropdownShow(e.target.value.length >= 4);
                     if (e.target.value === "") {
                       makeForm({
@@ -173,12 +175,13 @@ export default function UserUpdateForm() {
                       });
                     }
                   }}
-                  onFocus={() => searchTerm.length >= 4 && setUserDropdownShow(true)}
+                  onFocus={() => userLookup.length >= 4 && setUserDropdownShow(true)}
                   onBlur={() => setTimeout(() => setUserDropdownShow(false), 150)}
+                  placeholder="Nickname"
                   autoComplete="off"
                 />
               </FloatingLabel>
-              {searchTerm.length >= 2 &&
+              {userLookup.length >= 4 &&
                 searchResults &&
                 searchResults.users &&
                 searchResults.users.length > 0 &&
@@ -215,12 +218,7 @@ export default function UserUpdateForm() {
           </Col>
           <Col lg="6">
             <FloatingLabel controlId="userUpdateMail" label="Email">
-              <Form.Control
-                type="email"
-                value={form.email}
-                autoComplete="off"
-                readOnly
-              />
+              <Form.Control type="email" value={form.email} placeholder="Email" autoComplete="off" readOnly />
             </FloatingLabel>
           </Col>
           <Col lg="6">
@@ -229,6 +227,7 @@ export default function UserUpdateForm() {
                 type="url"
                 value={form.website}
                 onChange={(e) => handleFormChange("website", e.target.value)}
+                placeholder="Website"
                 autoComplete="off"
               />
             </FloatingLabel>
@@ -239,16 +238,18 @@ export default function UserUpdateForm() {
                 type="url"
                 value={form.avatar}
                 onChange={(e) => handleFormChange("avatar", e.target.value)}
+                placeholder="Avatar URL"
                 autoComplete="off"
               />
             </FloatingLabel>
           </Col>
           <Col lg="12">
-            <FloatingLabel controlId="userUpdateInfo" label="Bio">
+            <FloatingLabel controlId="userUpdateInfo" label="Biography">
               <Form.Control
                 type="text"
                 value={form.bio}
                 onChange={(e) => handleFormChange("bio", e.target.value)}
+                placeholder="Biography"
                 autoComplete="off"
               />
             </FloatingLabel>
@@ -256,25 +257,20 @@ export default function UserUpdateForm() {
         </Row>
         <hr className="mt-2 mb-2" />
         <p className="small ps-2 pe-2 m-0">
-          Last seen on{" "}
-          <span className="fw-bold">
-            {form.last_login ? formatTime(form.last_login) : "Never"}
-          </span>
+          Last seen on <span className="fw-bold">{form.last_login ? formatTime(form.last_login) : "Never"}</span>
         </p>
         <p className="small ps-2 pe-2 m-0">
           Account created on{" "}
-          <span className="fw-bold">
-            {form.created_on ? formatTime(form.created_on) : "Unknown"}
-          </span>
+          <span className="fw-bold">{form.created_on ? formatTime(form.created_on) : "Unknown"}</span>
         </p>
         <hr className="mt-2 mb-0" />
         <Row className="mt-0 mb-0 ms-1 me-1 g-2">
           <Col lg="6">
             <Button
               variant="outline-secondary"
-              className="d-grid"
+              className="d-grid w-100"
               size="sm"
-              onClick={handleTask}
+              onClick={handleUpdate}
               disabled={!form.id || isUpdating}
             >
               {isUpdating ? "Updating..." : "Update"}
@@ -283,7 +279,7 @@ export default function UserUpdateForm() {
           <Col lg="6">
             <Button
               variant="outline-secondary"
-              className="d-grid mb-2"
+              className="d-grid w-100 mb-2"
               size="sm"
               onClick={handleToggleOptOut}
               disabled={!form.id || isToggling}

--- a/frontend/src/features/call.js
+++ b/frontend/src/features/call.js
@@ -249,10 +249,7 @@ export const callUnit = createApi({
           "Content-Type": "application/json",
         },
       }),
-      invalidatesTags: (result, error, { user_id }) => [
-        { type: "Identity", id: user_id },
-        "IdentitySearch",
-      ],
+      invalidatesTags: (result, error, { user_id }) => [{ type: "Identity", id: user_id }, "IdentitySearch"],
     }),
     toggleIdentityOptOut: builder.mutation({
       query: ({ user_id, opt_out }) => ({
@@ -264,10 +261,7 @@ export const callUnit = createApi({
           "Content-Type": "application/json",
         },
       }),
-      invalidatesTags: (result, error, { user_id }) => [
-        { type: "Identity", id: user_id },
-        "IdentitySearch",
-      ],
+      invalidatesTags: (result, error, { user_id }) => [{ type: "Identity", id: user_id }, "IdentitySearch"],
     }),
   }),
 });

--- a/frontend/src/features/call.js
+++ b/frontend/src/features/call.js
@@ -227,6 +227,18 @@ export const callUnit = createApi({
       }),
       invalidatesTags: ["Sanction"], // Reload Sanction on deletion
     }),
+    creationIdentity: builder.mutation({
+      query: (userData) => ({
+        url: "../api/admin/users",
+        method: "POST",
+        body: userData,
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+      invalidatesTags: ["IdentitySearch"],
+    }),
   }),
 });
 
@@ -251,6 +263,7 @@ export const {
   useUpdationAccoladeMutation,
   useCreationSanctionMutation,
   useDeletionSanctionMutation,
+  useCreationIdentityMutation,
 } = callUnit;
 
 export default callUnit.reducer;

--- a/frontend/src/features/call.js
+++ b/frontend/src/features/call.js
@@ -239,6 +239,36 @@ export const callUnit = createApi({
       }),
       invalidatesTags: ["IdentitySearch"],
     }),
+    updationIdentity: builder.mutation({
+      query: ({ user_id, filldata }) => ({
+        url: `../api/admin/users/${user_id}`,
+        method: "PUT",
+        body: filldata,
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+      invalidatesTags: (result, error, { user_id }) => [
+        { type: "Identity", id: user_id },
+        "IdentitySearch",
+      ],
+    }),
+    toggleIdentityOptOut: builder.mutation({
+      query: ({ user_id, opt_out }) => ({
+        url: `../api/admin/users/${user_id}/opt_out`,
+        method: "PUT",
+        body: { opt_out },
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+      invalidatesTags: (result, error, { user_id }) => [
+        { type: "Identity", id: user_id },
+        "IdentitySearch",
+      ],
+    }),
   }),
 });
 
@@ -264,6 +294,8 @@ export const {
   useCreationSanctionMutation,
   useDeletionSanctionMutation,
   useCreationIdentityMutation,
+  useUpdationIdentityMutation,
+  useToggleIdentityOptOutMutation,
 } = callUnit;
 
 export default callUnit.reducer;

--- a/frontend/src/routes/governor.jsx
+++ b/frontend/src/routes/governor.jsx
@@ -14,6 +14,7 @@ import BadgeCreationForm from "../crud/badges/create.jsx";
 import BadgeUpdateForm from "../crud/badges/update.jsx";
 import InvitationCreationForm from "../crud/invitations/create.jsx";
 import InvitationDeletionForm from "../crud/invitations/delete.jsx";
+import UserCreationForm from "../crud/users/create.jsx";
 import { loadUserData } from "../features/auth.js";
 import { hideLoad, showLoad } from "../features/part.js";
 import { owners } from "../features/util.js";
@@ -116,29 +117,7 @@ export default function Governor() {
               <Icon path={mdiAccountCircle} size={1} />
             </ListGroup.Item>
           </ListGroup>
-          <Card className="mb-2">
-            <Card.Body className="ps-0 pe-0 pt-2 pb-0">
-              <Card.Title className="mb-0 ps-2 dataelem">Create users</Card.Title>
-              <Card.Text className="mb-0 ps-2 small">Create accounts that will obtain felicitation</Card.Text>
-              <hr className="mt-2 mb-0" />
-              <Row className="mt-0 mb-2 ms-1 me-1 g-2">
-                <Col lg="6">
-                  <FloatingLabel controlId="userCreateName" label="Nickname">
-                    <Form.Control type="text" autoComplete="off" />
-                  </FloatingLabel>
-                </Col>
-                <Col lg="6">
-                  <FloatingLabel controlId="userCreateMail" label="Email">
-                    <Form.Control type="email" autoComplete="off" />
-                  </FloatingLabel>
-                </Col>
-              </Row>
-              <hr className="mt-2 mb-0" />
-              <Button as={Link} to="" variant="outline-secondary" className="d-grid m-2" size="sm">
-                Create
-              </Button>
-            </Card.Body>
-          </Card>
+          <UserCreationForm />
           <Card className="mb-2">
             <Card.Body className="ps-0 pe-0 pt-2 pb-0">
               <Card.Title className="mb-0 ps-2 dataelem">Update users</Card.Title>

--- a/frontend/src/routes/governor.jsx
+++ b/frontend/src/routes/governor.jsx
@@ -1,9 +1,9 @@
 import { mdiAccountCircle, mdiCrown, mdiCubeScan, mdiMedal, mdiShieldStarOutline } from "@mdi/js";
 import Icon from "@mdi/react";
 import { useEffect } from "react";
-import { Button, Card, Col, FloatingLabel, Form, ListGroup, Row } from "react-bootstrap";
+import { Card, ListGroup } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 
 import BaseNote from "../components/basenote.jsx";
 import AssertionCreationForm from "../crud/assertions/create.jsx";
@@ -15,6 +15,7 @@ import BadgeUpdateForm from "../crud/badges/update.jsx";
 import InvitationCreationForm from "../crud/invitations/create.jsx";
 import InvitationDeletionForm from "../crud/invitations/delete.jsx";
 import UserCreationForm from "../crud/users/create.jsx";
+import UserUpdateForm from "../crud/users/update.jsx";
 import { loadUserData } from "../features/auth.js";
 import { hideLoad, showLoad } from "../features/part.js";
 import { owners } from "../features/util.js";
@@ -118,55 +119,7 @@ export default function Governor() {
             </ListGroup.Item>
           </ListGroup>
           <UserCreationForm />
-          <Card className="mb-2">
-            <Card.Body className="ps-0 pe-0 pt-2 pb-0">
-              <Card.Title className="mb-0 ps-2 dataelem">Update users</Card.Title>
-              <Card.Text className="mb-0 ps-2 small">Update accounts that will obtain felicitation</Card.Text>
-              <hr className="mt-2 mb-0" />
-              <Row className="mt-0 mb-2 ms-1 me-1 g-2">
-                <Col lg="6">
-                  <FloatingLabel controlId="userUpdateName" label="Nickname">
-                    <Form.Control type="text" autoComplete="off" />
-                  </FloatingLabel>
-                </Col>
-                <Col lg="6">
-                  <FloatingLabel controlId="userUpdateMail" label="Email">
-                    <Form.Control type="email" autoComplete="off" />
-                  </FloatingLabel>
-                </Col>
-                <Col lg="6">
-                  <FloatingLabel controlId="userUpdateSite" label="Website">
-                    <Form.Control type="url" autoComplete="off" />
-                  </FloatingLabel>
-                </Col>
-                <Col lg="6">
-                  <FloatingLabel controlId="userUpdateInfo" label="Bio">
-                    <Form.Control type="text" autoComplete="off" />
-                  </FloatingLabel>
-                </Col>
-              </Row>
-              <hr className="mt-2 mb-2" />
-              <p className="small ps-2 pe-2 m-0">
-                Last seen on <span className="fw-bold">December 12, 2025 at 00:00 AM GMT+5:30</span>
-              </p>
-              <p className="small ps-2 pe-2 m-0">
-                Account created on <span className="fw-bold">December 12, 2025 at 00:00 AM GMT+5:30</span>
-              </p>
-              <hr className="mt-2 mb-0" />
-              <Row className="mt-0 mb-0 ms-1 me-1 g-2">
-                <Col lg="6">
-                  <Button as={Link} to="" variant="outline-secondary" className="d-grid" size="sm">
-                    Update
-                  </Button>
-                </Col>
-                <Col lg="6">
-                  <Button as={Link} to="" variant="outline-secondary" className="d-grid mb-2" size="sm">
-                    Deactivate
-                  </Button>
-                </Col>
-              </Row>
-            </Card.Body>
-          </Card>
+          <UserUpdateForm />
           <hr className="mt-2 mb-2" />
           <ListGroup className="mb-2">
             <ListGroup.Item

--- a/tahrir/endpoints/admin/users.py
+++ b/tahrir/endpoints/admin/users.py
@@ -31,3 +31,29 @@ def add_user():
     )
 
     return jsonify({"message": f"User {data.get('email')!r} added successfully"}), 201
+
+
+@bp.route("/api/admin/users/<string:user_id>", methods=["PUT"])
+@csrf.exempt
+@oidc.require_login
+@require_admin
+def update_user(user_id: str):
+    """Endpoint to update existing user"""
+
+    if not user_id:
+        return abort(400, "No badge ID provided")
+
+    data = request.get_json()
+    if not data:
+        return abort(400, "No details provided")
+
+    result = g.tahrirdb.update_person(
+        nickname=user_id,
+        website=data.get("website"),
+        bio=data.get("bio"),
+        avatar=data.get("avatar"),
+    )
+    if not result:
+        return abort(404, f"User {user_id!r} not found")
+
+    return jsonify({"message": f"User {user_id!r} updated successfully"})

--- a/tahrir/endpoints/admin/users.py
+++ b/tahrir/endpoints/admin/users.py
@@ -1,7 +1,7 @@
 from flask import abort, g, jsonify, request
 
 from ...app import csrf, oidc
-from ...utils.user import require_admin
+from ...utils.user import get_person, require_admin
 from . import blueprint as bp
 
 
@@ -57,3 +57,26 @@ def update_user(user_id: str):
         return abort(404, f"User {user_id!r} not found")
 
     return jsonify({"message": f"User {user_id!r} updated successfully"})
+
+
+@bp.route("/api/admin/users/<string:user_id>/opt_out", methods=["PUT"])
+@csrf.exempt
+@oidc.require_login
+@require_admin
+def user_opt_out(user_id: str):
+    """Endpoint to update user account settings."""
+
+    user = get_person(user_id)
+
+    if not user:
+        abort(404, f"No such user {user_id!r}")
+
+    data = request.get_json()
+    if data is None or "opt_out" not in data:
+        abort(400, "No opt_out status provided")
+
+    # Opt Out functionality should be made available in tahrir-api
+    user.opt_out = data.get("opt_out")
+    g.tahrirdb.session.commit()
+
+    return jsonify({"message": "User updated successfully"})

--- a/tahrir/endpoints/admin/users.py
+++ b/tahrir/endpoints/admin/users.py
@@ -41,7 +41,7 @@ def update_user(user_id: str):
     """Endpoint to update existing user"""
 
     if not user_id:
-        return abort(400, "No badge ID provided")
+        return abort(400, "No user ID provided")
 
     data = request.get_json()
     if not data:
@@ -75,7 +75,7 @@ def user_opt_out(user_id: str):
     if data is None or "opt_out" not in data:
         abort(400, "No opt_out status provided")
 
-    # Opt Out functionality should be made available in tahrir-api
+    # Opt out functionality should be made available in tahrir-api
     user.opt_out = data.get("opt_out")
     g.tahrirdb.session.commit()
 

--- a/tahrir/endpoints/users.py
+++ b/tahrir/endpoints/users.py
@@ -18,11 +18,8 @@ def search_users_by_string(search_string: str):
     limit = request.args.get("limit", 100, type=int)
 
     collection = (
-        g.tahrirdb.get_all_persons()
-        .filter(
-            m.Person.opt_out.is_(False)
-            & sa.func.lower(m.Person.nickname).like(f"%{search_string.lower()}%")
-        )
+        g.tahrirdb.get_all_persons(include_opted_out=True)
+        .filter(sa.func.lower(m.Person.nickname).like(f"%{search_string.lower()}%"))
         .all()
     )
 
@@ -36,6 +33,7 @@ def search_users_by_string(search_string: str):
                 "email": item.avatar,
                 "last_login": item.last_login.timestamp() if item.last_login else None,
                 "nickname": item.nickname,
+                "opt_out": item.opt_out,
                 "rank": item.rank,
                 "website": item.website,
             }

--- a/tahrir/endpoints/users.py
+++ b/tahrir/endpoints/users.py
@@ -78,7 +78,7 @@ def get_user_by_id(user_id: str):
 
 @bp.route("/api/users/opt_out", methods=["PUT"])
 @require_login
-def update_user_by_id():
+def user_opt_out():
     """Endpoint to update user account settings."""
 
     data = request.get_json()


### PR DESCRIPTION
## Summary
Currently, this PR adds a PUT endpoint for updating user relation, allowing administrators to update certain fields of a user's account.

I'll be adding the frontend for this endpoint along with the endpoint for creation of user which is currently not yet implemented.

## Key changes:
Added new PUT endpoint for updating for USER relation

## Endpoints added:
**PUT** `/api/admin/users/<string:user_id>` - updates an existing user
<img width="1915" height="341" alt="Screenshot From 2026-01-17 18-28-11" src="https://github.com/user-attachments/assets/c8fec24f-3894-4d64-9b4f-4478bbfd4df1" />

@gridhead, I'm keeping this PR as draft until I'm done implementing the frontend (which will take me some time :cry:).