### PR TITLE
fix: improve CSV badge awarding with validation and error reporting

### DIFF
--- a/tahrir/views/admin.py
+++ b/tahrir/views/admin.py
@@ -183,41 +183,92 @@ def admin():
 @oidc.require_login
 @require_admin
 def award_from_csv():
+    if "csv-file" not in request.files:
+        flash("No file uploaded.")
+        return redirect(url_for("tahrir.admin"))
+
     csv_file = request.files["csv-file"]
+
+    if csv_file.filename == "":
+        flash("No file selected.")
+        return redirect(url_for("tahrir.admin"))
+
     successful_awards = 0
-    """TODO: We need some validation here, and flash
-    a message whether the awards were successful or not.
-    This should be added at the same time that flash
-    messages are added to the admin panel."""
-    awards = dict()  # str(badge_id) : str(person_email)
+    not_found_badges = []
+    not_found_persons = []
+    already_awarded = []
+    malformed_lines = []
+
+    awards = {}  # str(email) : str(badge_id)
+
     for line in csv_file:
+        # Decode bytes to string (Python 3 fix)
+        line = line.decode("utf-8").strip()
+
+        # Skip empty lines
+        if not line:
+            continue
+
         values = line.split(",")
-        """Through the following if statement, it doesn't matter
-        if the line has been entered as "email, badge" or
-        "badge, email". The awards dict will be normalized
-        to be "badge, email". This code assumes that one of the
-        two values will be a valid email address."""
-        if values[0].find("@") == -1:
-            # If there is no @ sign in the first value, it is the badge id.
-            awards[values[1].strip()] = values[0].strip()
+
+        # Skip malformed lines that don't have exactly 2 values
+        if len(values) != 2:
+            malformed_lines.append(line)
+            continue
+
+        value_a = values[0].strip()
+        value_b = values[1].strip()
+
+        # Normalize to email -> badge_id regardless of column order
+        if "@" in value_a:
+            email, badge_id = value_a, value_b
         else:
-            # If there is an @ sign in the first value, it is the email.
-            awards[values[0].strip()] = values[1].strip()
+            badge_id, email = value_a, value_b
+
+        awards[email] = badge_id
 
     for email, badge_id in awards.items():
-        # First, if the person doesn't exist, we automatically
-        # create the person in this special case.
+        # Validate badge exists first
+        if not g.tahrirdb.badge_exists(badge_id):
+            not_found_badges.append(badge_id)
+            continue
+
+        # Create person if they don't exist
         if not g.tahrirdb.person_exists(email=email):
             g.tahrirdb.add_person(email)
-        # Second, if the badge exists and the person has yet
-        # to be awarded it, give it to them.
-        if g.tahrirdb.badge_exists(badge_id):
-            if not g.tahrirdb.assertion_exists(badge_id, email):
-                # The None will default to datetime.now().
-                g.tahrirdb.add_assertion(badge_id, email, None)
-                successful_awards += 1
+            not_found_persons.append(email)
 
-    flash(f"Successfully awarded {successful_awards} badges.")
+        # Award badge if not already awarded
+        if not g.tahrirdb.assertion_exists(badge_id, email):
+            g.tahrirdb.add_assertion(badge_id, email, None)
+            successful_awards += 1
+        else:
+            already_awarded.append(f"{email} ({badge_id})")
+
+    # Flash a full summary back to the admin
+    flash(f"Successfully awarded {successful_awards} badge(s).")
+
+    if not_found_persons:
+        flash(
+            f"The following {len(not_found_persons)} user(s) did not exist "
+            f"and were created: {', '.join(not_found_persons)}"
+        )
+    if already_awarded:
+        flash(
+            f"The following {len(already_awarded)} award(s) were skipped "
+            f"(already awarded): {', '.join(already_awarded)}"
+        )
+    if not_found_badges:
+        flash(
+            f"The following {len(not_found_badges)} badge(s) were not found "
+            f"and skipped: {', '.join(not_found_badges)}"
+        )
+    if malformed_lines:
+        flash(
+            f"The following {len(malformed_lines)} line(s) were malformed "
+            f"and skipped: {', '.join(malformed_lines)}"
+        )
+
     return redirect(url_for("tahrir.admin"))
 
 

--- a/tests/test_award_from_csv.py
+++ b/tests/test_award_from_csv.py
@@ -1,0 +1,85 @@
+
+"""Test tahrir.views.admin.award_from_csv"""
+
+import io
+
+import pytest
+
+from tahrir.database import db
+
+
+@pytest.fixture
+def dummy_badge(app, dummy_issuer):
+    tahrir_db = db.get_db()
+    return tahrir_db.add_badge(
+        name="test-badge",
+        image="dummy-image",
+        desc="dummy-desc",
+        criteria="",
+        issuer_id=dummy_issuer,
+    )
+
+
+def test_award_from_csv_no_file(client):
+    """Test that missing file upload is handled gracefully."""
+    response = client.post(
+        "/award_from_csv",
+        data={},
+        content_type="multipart/form-data",
+    )
+    # Should redirect back to admin, not crash
+    assert response.status_code == 302
+
+
+def test_award_from_csv_valid_email_first(client, dummy_badge):
+    """Test CSV with email in first column."""
+    csv_content = b"test@example.com,test-badge\n"
+    response = client.post(
+        "/award_from_csv",
+        data={"csv-file": (io.BytesIO(csv_content), "test.csv")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 302
+
+
+def test_award_from_csv_valid_badge_first(client, dummy_badge):
+    """Test CSV with badge_id in first column."""
+    csv_content = b"test-badge,test@example.com\n"
+    response = client.post(
+        "/award_from_csv",
+        data={"csv-file": (io.BytesIO(csv_content), "test.csv")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 302
+
+
+def test_award_from_csv_empty_file(client):
+    """Test that an empty CSV file is handled gracefully."""
+    response = client.post(
+        "/award_from_csv",
+        data={"csv-file": (io.BytesIO(b""), "test.csv")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 302
+
+
+def test_award_from_csv_malformed_line(client, dummy_badge):
+    """Test that malformed lines are skipped without crashing."""
+    csv_content = b"this-is-not-valid\ntest@example.com,test-badge\n"
+    response = client.post(
+        "/award_from_csv",
+        data={"csv-file": (io.BytesIO(csv_content), "test.csv")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 302
+
+
+def test_award_from_csv_nonexistent_badge(client):
+    """Test that nonexistent badge IDs are skipped gracefully."""
+    csv_content = b"test@example.com,badge-that-does-not-exist\n"
+    response = client.post(
+        "/award_from_csv",
+        data={"csv-file": (io.BytesIO(csv_content), "test.csv")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 302


### PR DESCRIPTION

## Fix: CSV badge awarding with validation and error reporting

Fixes #348 

### Problem
The existing `award_from_csv()` had multiple issues:
- In Python 3, file lines are `bytes` not `str`, causing `.split(",")` to silently fail
- No validation for missing or empty file uploads
- No feedback to the admin on what happened, the original requester specifically asked to know which accounts weren't found
- No handling of malformed CSV lines

### Changes
- Added `.decode("utf-8")` fix for Python 3 bytes handling
- Added file presence and empty filename validation
- Added detailed summary flash messages covering:
  -  Successful awards count
  - Users that didn't exist and were auto-created
  - Skipped duplicates (already awarded)
  -  Badge IDs not found in the system
  -  Malformed lines that couldn't be parsed
-  Added tests

