### PR TITLE
Refactor badge builder to WTForms and Jinja YAML output

### DIFF
--- a/tahrir/templates/builder.html
+++ b/tahrir/templates/builder.html
@@ -1,7 +1,6 @@
 {% extends '_base.html' %}
 
 {% block body %}
-<script type="text/javascript" src="{{ url_for('static', filename='/js/builder.js') }}"></script>
 <div class="page">
   <div class="grid-100">
     <h1 class="section-header">Badge Builder</h1>
@@ -29,55 +28,38 @@
     <div class="grid-50">
       <h3>Badge Builder</h3>
       <form id="builder-form" method="POST">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {{ form.hidden_tag() }}
         <table>
           <tr>
-            <td><label for="badge-name">Badge Name</label></td>
-            <td><input name="badge-name" tabindex="1" /></td>
-            <td><label for="discussion">Discussion URL</label></td>
-            <td><input name="discussion" tabindex="4" /></td>
+            <td>{{ form.badge_name.label }}</td>
+            <td>{{ form.badge_name() }}</td>
+            <td>{{ form.discussion.label }}</td>
+            <td>{{ form.discussion() }}</td>
           </tr>
           <tr>
-            <td><label for="badge-description">Badge Description</label></td>
-            <td><input name="badge-description" tabindex="2" /></td>
-            <td><label for="image">Image URL</label></td>
-            <td><input name="image" tabindex="5" /></td>
+            <td>{{ form.badge_description.label }}</td>
+            <td>{{ form.badge_description() }}</td>
+            <td>{{ form.image.label }}</td>
+            <td>{{ form.image() }}</td>
           </tr>
           <tr>
-            <td><label for="badge-creator">Badge Creator</label></td>
-            <td>
-              <input name="badge-creator" tabindex="3" value="{{ default_creator if default_creator else '' }}" />
-            </td>
-            <td><label for="issuer">Issuer ID</label></td>
-            <td>
-              <input name="issuer" tabindex="6" value="{{ config['TAHRIR_DEFAULT_ISSUER'] }}" />
-            </td>
+            <td>{{ form.badge_creator.label }}</td>
+            <td>{{ form.badge_creator() }}</td>
+            <td>{{ form.issuer.label }}</td>
+            <td>{{ form.issuer() }}</td>
           </tr>
           <tr>
-            <td><label for="trigger-topic">Trigger Topic</label></td>
-            <td><input name="trigger-topic" tabindex="7" /></td>
-            <td><label for="condition">Condition</label></td>
-            <td><input name="condition" tabindex="8" value="greater than or equal to: 10" /></td>
+            <td>{{ form.trigger_topic.label }}</td>
+            <td>{{ form.trigger_topic() }}</td>
+            <td>{{ form.condition_operator.label }}</td>
+            <td>{{ form.condition_operator() }} {{ form.condition_value(size=5) }}</td>
           </tr>
           <tr>
-            <td>
-              <label for="previous">Previous value</label>
-            </td>
-            <td colspan="3">
-              <textarea name="previous" cols=40 rows=7>
-filter:
-  topics:
-    - message.topic
-  users:
-    - recipient
-  rows_per_page: 0
-operation: count
-</textarea>
-            </td>
+            <td>{{ form.previous.label }}</td>
+            <td colspan="3">{{ form.previous(cols=40, rows=7) }}</td>
+          </tr>
           <tr>
-            <td colspan="4">
-              <input name="generate" type="submit" action="{{ url_for('tahrir.builder') }}" value="Generate" />
-            </td>
+            <td colspan="4">{{ form.generate() }}</td>
           </tr>
         </table>
       </form>
@@ -107,8 +89,41 @@ operation: count
 END COMMENTING OUT PREVIEW AREA -->
 
   <h3>Output</h3>
-  {% if badge_yaml %}
-    <textarea rows="30" cols="80">{{badge_yaml}}</textarea>
+  {% if badge_yaml_data %}
+    {% set d = badge_yaml_data %}
+    <textarea rows="30" cols="80">
+%YAML 1.2
+---
+
+# This is some metadata about the badge.
+name:           {{ d.badge_name }}
+description:    {{ d.badge_description }}
+creator:        {{ d.badge_creator }}
+
+# This is a link to the discussion about adopting this as a for-real badge.
+discussion:     {{ d.discussion }}
+
+# A link to the image for the badge.
+image_url:      {{ d.image }}
+
+# The issuer.
+issuer_id:      {{ d.issuer }}
+
+# We'll perform our more costly check (defined below)
+# only when we receive messages that match this trigger.
+trigger:
+  topic:        {{ d.trigger_topic }}
+
+# Award the badge under these conditions:
+condition:
+  {{ d.condition_operator }}: {{ d.condition_value }}
+
+# If the messages matches for the user for the first time, look into previous messages to get the count:
+previous:
+{{ d.previous | indent(2, true) }}
+
+(This section is under construction.)
+    </textarea>
   {% else %}
     <textarea rows="30" cols="80">Badge YAML will appear here.</textarea>
   {% endif %}

--- a/tahrir/utils/badge.py
+++ b/tahrir/utils/badge.py
@@ -118,37 +118,3 @@ def convert_name_to_id(name):
         badge_id = badge_id.replace(a, b)
 
     return badge_id
-
-
-def generate_badge_yaml(postdict):
-    return (
-        "%YAML 1.2\n"
-        "---\n"
-        "\n"
-        "# This is some metadata about the badge.\n"
-        "name:           " + postdict.get("badge-name", default="") + "\n"
-        "description:    " + postdict.get("badge-description", default="") + "\n"
-        "creator:        " + postdict.get("badge-creator", default="") + "\n"
-        "\n"
-        "# This is a link to the discussion about adopting this as\n"
-        "a for-real badge\n"
-        "discussion:     " + postdict.get("discussion", default="") + "\n"
-        "\n"
-        "# A link to the image for the badge.\n"
-        "image_url:      " + postdict.get("image", default="") + "\n"
-        "\n"
-        "# The issuer.\n"
-        "issuer_id:      " + postdict.get("issuer", default="") + "\n"
-        "\n"
-        "# We'll perform our more costly check (defined below)\n"
-        "# only when we receive messages that match this trigger.\n"
-        "trigger:\n"
-        "  topic:        " + postdict.get("trigger-topic", default="") + "\n"
-        "\n"
-        "# Award the badge under these conditions:\n"
-        "condition:\n" + postdict.get("condition", default="") + "\n"
-        "# If the messages matches for the user for the first time, look into previous messages"
-        " to get the count:\n"
-        "previous:\n" + postdict.get("previous", default="") + "\n"
-        "(This section is under construction.)"
-    )

--- a/tahrir/views/admin.py
+++ b/tahrir/views/admin.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-
+from flask_wtf import FlaskForm
 from flask import abort, current_app, flash, g, redirect, render_template, request, url_for
-
+from wtforms import IntegerField, SelectField, StringField, SubmitField, TextAreaField
 from tahrir.app import oidc
-from tahrir.utils.badge import convert_name_to_id, generate_badge_yaml
+from tahrir.utils.badge import convert_name_to_id
 from tahrir.utils.user import require_admin
-
+from wtforms.validators import DataRequired, NumberRange, Optional
 from . import blueprint as bp
 
 
@@ -246,12 +246,56 @@ def builder():
     if g.oidc_user.person:
         default_creator = g.oidc_user.person.nickname or g.oidc_user.person.email
 
-    badge_yaml = None
-    if request.method == "POST":
-        badge_yaml = generate_badge_yaml(request.form)
+    form = BadgeBuilderForm()
+
+    if request.method == "GET":
+        form.badge_creator.data = default_creator or ""
+        form.issuer.data = current_app.config["TAHRIR_DEFAULT_ISSUER"]
+        form.condition_operator.data = "greater than or equal to"
+        form.condition_value.data = 10
+        form.previous.data = """filter:
+  topics:
+    - message.topic
+  users:
+    - recipient
+  rows_per_page: 0
+operation: count
+"""
+
+    badge_yaml_data = None
+    if form.validate_on_submit():
+        badge_yaml_data = form.data
 
     return render_template(
         "builder.html",
-        default_creator=default_creator,
-        badge_yaml=badge_yaml,
+        form=form,
+        badge_yaml_data=badge_yaml_data,
     )
+
+class BadgeBuilderForm(FlaskForm):
+    badge_name = StringField("Badge Name", validators=[DataRequired()])
+    badge_description = StringField("Badge Description", validators=[DataRequired()])
+    badge_creator = StringField("Badge Creator", validators=[Optional()])
+    discussion = StringField("Discussion URL", validators=[Optional()])
+    image = StringField("Image URL", validators=[Optional()])
+    issuer = StringField("Issuer ID", validators=[DataRequired()])
+    trigger_topic = StringField("Trigger Topic", validators=[DataRequired()])
+
+    # Limited options instead of free text
+    condition_operator = SelectField(
+        "Condition",
+        choices=[
+            ("greater than or equal to", "greater than or equal to"),
+            ("greater than", "greater than"),
+            ("equal to", "equal to"),
+            ("less than", "less than"),
+            ("less than or equal to", "less than or equal to"),
+        ],
+        validators=[DataRequired()],
+    )
+    condition_value = IntegerField(
+        "Condition Value", validators=[DataRequired(), NumberRange(min=0)]
+    )
+
+    previous = TextAreaField("Previous value", validators=[DataRequired()])
+    generate = SubmitField("Generate")


### PR DESCRIPTION
Refactors the Badge Builder to use WTForms for cleaner form handling and maintainability. The builder now uses constrained select options for condition operators, and YAML output is generated directly in the Jinja template instead of Python string templating. Also removes obsolete builder-side YAML generation code and unused JS include tied to the old flow.

closes issue #520