### PR TITLE
Replace history_limit with page-based pagination on user profile

### DIFF
--- a/tahrir/templates/user.html
+++ b/tahrir/templates/user.html
@@ -152,7 +152,7 @@
     <div class="shadow mobile-hidden">
       <h1 class="section-header">History</h1>
       <div class="padded-content clearfix">
-        {% for assertion in (user.assertions|sort(attribute="issued_on", reverse=True))[:history_limit] %}
+        {% for assertion in paginated_assertions %}
           <div class="grid-container">
             {{ badge_thumbnail(assertion.badge, 64, 33) }}
             <div class="grid-66 text-64"><p>received on {{assertion.issued_on.strftime('%Y-%m-%d')}}
@@ -162,13 +162,17 @@
               </p></div>
           </div>
         {% endfor %}
-        {% if history_limit < user.assertions|length %}
-        <div class="grid-container">
-          <div class="grid-100 text-64"><p>
-            This is only the last {{history_limit}} entries.
-            <a href="{{ url_for('tahrir.user', user_id=user.nickname or user.id, history_limit=user.assertions|length) }}">
-              Click here to see all of them</a>.
-          </p></div>
+        {% if total_pages > 1 %}
+        <div class="grid-container" style="text-align: center; padding-top: 10px;">
+          <div class="grid-100">
+            {% if page > 1 %}
+              <a class="pretty-button" href="{{ url_for('tahrir.user', user_id=user.nickname or user.id, page=page - 1, per_page=per_page) }}">&laquo; Previous</a>
+            {% endif %}
+            <span style="margin: 0 10px;">Page {{ page }} of {{ total_pages }}</span>
+            {% if page < total_pages %}
+              <a class="pretty-button" href="{{ url_for('tahrir.user', user_id=user.nickname or user.id, page=page + 1, per_page=per_page) }}">Next &raquo;</a>
+            {% endif %}
+          </div>
         </div>
         {% endif %}
       </div> <!-- End padded content. -->

--- a/tahrir/views/user.py
+++ b/tahrir/views/user.py
@@ -62,9 +62,13 @@ def user(user_id):
     person = get_person(user_id)
 
     try:
-        history_limit = int(request.args.get("history_limit", 10))
+        page = int(request.args.get("page", 1))
+        per_page = int(request.args.get("per_page", 10))
     except ValueError as e:
-        abort(400, f"Wrong value for the 'history_limit' parameter: {e}")
+        abort(400, f"Wrong value for pagination parameter: {e}")
+
+    if page < 1 or per_page < 1:
+        abort(400, "Pagination parameters must be positive integers")
 
     if not person:
         abort(404, f"No such user {user_id!r}")
@@ -90,10 +94,22 @@ def user(user_id):
         i for i in g.tahrirdb.get_invitations(person.id) if i.expires_on > datetime.now()
     ]
 
+    # Paginate the awarding history.
+    sorted_assertions = sorted(person.assertions, key=lambda x: x.issued_on, reverse=True)
+    total_assertions = len(sorted_assertions)
+    total_pages = max(1, (total_assertions + per_page - 1) // per_page)
+    page = min(page, total_pages)
+    start = (page - 1) * per_page
+    paginated_assertions = sorted_assertions[start : start + per_page]
+
     user_info = dict(
         user=person,
         invitations=invitations,
-        history_limit=history_limit,
+        paginated_assertions=paginated_assertions,
+        page=page,
+        per_page=per_page,
+        total_pages=total_pages,
+        total_assertions=total_assertions,
     )
 
     user_info.update(_get_user_badge_info(person))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from tahrir_api.utils import get_db_manager_from_uri
 
 from tahrir.app import create_app
+from tahrir.cache import cache
 from tahrir.database import db
 
 
@@ -27,6 +28,10 @@ def app_config(tmpdir):
 
 @pytest.fixture
 def app(app_config):
+    # Reset the dogpile cache singleton so create_app can re-configure it.
+    cache.region_invalidator = None
+    cache.__dict__.pop("backend", None)
+
     app = create_app(app_config)
     with app.app_context():
         db_manager = get_db_manager_from_uri(app.config["SQLALCHEMY_DATABASE_URI"])

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,130 @@
+"""Tests for user view pagination."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from tahrir.database import db
+
+
+@pytest.fixture
+def dummy_badge(app, dummy_issuer):
+    tahrir_db = db.get_db()
+    return tahrir_db.add_badge(
+        name="test-badge",
+        image="dummy-image",
+        desc="dummy-desc",
+        criteria="",
+        issuer_id=dummy_issuer,
+    )
+
+
+@pytest.fixture
+def user_with_badges(app, dummy_issuer):
+    """Create a user with 15 badge assertions for pagination testing."""
+    tahrir_db = db.get_db()
+    person_email = "test-user@fedoraproject.org"
+    tahrir_db.add_person(person_email, nickname="test-user")
+
+    badges = []
+    for i in range(15):
+        badge_id = tahrir_db.add_badge(
+            name=f"badge-{i}",
+            image=f"image-{i}",
+            desc=f"desc-{i}",
+            criteria="",
+            issuer_id=dummy_issuer,
+        )
+        badges.append(badge_id)
+
+    base_date = datetime(2025, 1, 1)
+    for i, badge_id in enumerate(badges):
+        tahrir_db.add_assertion(
+            badge_id,
+            person_email,
+            (base_date + timedelta(days=i)),
+        )
+
+    return tahrir_db.get_person(person_email=person_email)
+
+
+def test_user_page_default_pagination(client, user_with_badges):
+    """Default page=1, per_page=10 shows first 10 assertions."""
+    response = client.get("/user/test-user")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Page 1 of 2" in html
+    assert "Next &raquo;" in html
+    # Should not show previous on first page
+    assert "&laquo; Previous" not in html
+
+
+def test_user_page_second_page(client, user_with_badges):
+    """Page 2 shows remaining assertions."""
+    response = client.get("/user/test-user?page=2")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Page 2 of 2" in html
+    assert "&laquo; Previous" in html
+    # Should not show next on last page
+    assert "Next &raquo;" not in html
+
+
+def test_user_page_custom_per_page(client, user_with_badges):
+    """Custom per_page changes the number of pages."""
+    response = client.get("/user/test-user?per_page=5")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Page 1 of 3" in html
+
+
+def test_user_page_beyond_total_clamps(client, user_with_badges):
+    """Page beyond total_pages clamps to last page."""
+    response = client.get("/user/test-user?page=999")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Page 2 of 2" in html
+
+
+def test_user_page_invalid_page_value(client, user_with_badges):
+    """Non-integer page value returns 400."""
+    response = client.get("/user/test-user?page=abc")
+    assert response.status_code == 400
+
+
+def test_user_page_invalid_per_page_value(client, user_with_badges):
+    """Non-integer per_page value returns 400."""
+    response = client.get("/user/test-user?per_page=abc")
+    assert response.status_code == 400
+
+
+def test_user_page_zero_page(client, user_with_badges):
+    """Page 0 returns 400."""
+    response = client.get("/user/test-user?page=0")
+    assert response.status_code == 400
+
+
+def test_user_page_negative_per_page(client, user_with_badges):
+    """Negative per_page returns 400."""
+    response = client.get("/user/test-user?per_page=-1")
+    assert response.status_code == 400
+
+
+def test_user_page_single_page(client, user_with_badges):
+    """When all badges fit on one page, no pagination controls shown."""
+    response = client.get("/user/test-user?per_page=20")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Page 1 of 1" not in html
+    assert "Next &raquo;" not in html
+    assert "&laquo; Previous" not in html
+
+
+def test_user_no_badges(client, app, dummy_badge):
+    """User with no badges shows no history section."""
+    tahrir_db = db.get_db()
+    tahrir_db.add_person("nobadges@fedoraproject.org", nickname="nobadges-user")
+    response = client.get("/user/nobadges-user")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Page " not in html


### PR DESCRIPTION
## Summary
  - Replace the `history_limit` query parameter with `page` and `per_page`  
  parameters on the user badge awarding history section
  - Add Previous/Next navigation controls when history spans multiple pages 
  - Fix dogpile cache singleton issue in test fixtures to support multiple  
  test files using the `app` fixture
  - Add 10 tests covering pagination defaults, custom values, input
  validation, and edge cases

  ## Test plan
  - [x] `poetry run pytest tests/test_user.py -v` — all 10 new tests pass   
  - [x] `poetry run pytest tests/ -v` — full suite (15 tests) passes        
  - [x] `ruff check` and `black --check` pass

  Fixes #742