### PR TITLE
Fix add_tag view to not accept request as parameter

### DIFF
--- a/tahrir/views/admin.py
+++ b/tahrir/views/admin.py
@@ -224,7 +224,7 @@ def award_from_csv():
 @bp.route("/add_tag", methods=["POST"])
 @oidc.require_login
 @require_admin
-def add_tag(request):
+def add_tag():
     badge_id = request.form.get("badge_id")
     badge = g.tahrirdb.get_badge(badge_id)
     if not badge:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from tahrir_api.utils import get_db_manager_from_uri
 
 from tahrir.app import create_app
+from tahrir.cache import cache
 from tahrir.database import db
 
 
@@ -27,6 +28,8 @@ def app_config(tmpdir):
 
 @pytest.fixture
 def app(app_config):
+    # Reset the dogpile cache singleton so it can be re-configured
+    cache.__dict__.pop("backend", None)
     app = create_app(app_config)
     with app.app_context():
         db_manager = get_db_manager_from_uri(app.config["SQLALCHEMY_DATABASE_URI"])

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tahrir.database import db
+
+
+@pytest.fixture
+def dummy_badge(app, dummy_issuer):
+    tahrir_db = db.get_db()
+    return tahrir_db.add_badge(
+        name="test-badge",
+        image="dummy-image",
+        desc="dummy-desc",
+        criteria="",
+        issuer_id=dummy_issuer,
+        tags="existing-tag,",
+    )
+
+
+def test_add_tag(client, dummy_badge):
+    """Test that the add_tag endpoint adds tags to a badge."""
+    response = client.post(
+        "/add_tag",
+        data={"badge_id": "test-badge", "tags": "new-tag, another-tag"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    tahrir_db = db.get_db()
+    badge = tahrir_db.get_badge("test-badge")
+    tags = {t.strip() for t in badge.tags.split(",") if t.strip()}
+    assert "existing-tag" in tags
+    assert "new-tag" in tags
+    assert "another-tag" in tags
+
+
+def test_add_tag_nonexistent_badge(client, dummy_badge):
+    """Test that add_tag returns 404 for a badge that doesn't exist."""
+    response = client.post(
+        "/add_tag",
+        data={"badge_id": "nonexistent-badge", "tags": "some-tag"},
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
Fixes #840 
The add_tag view was defined as def add_tag(request): but Flask views don't receive request as a positional argument, causing a TypeError on every call. Also adds tests and fixes dogpile cache test isolation in conftest.