### PR TITLE
Fix Vagrantfile for macOS/Windows and supported Fedora box (#831)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,23 +2,42 @@
 # vi: set ft=ruby :
 ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 
+# Fedora 38 is EOL and the old Fedora 38 Vagrant box URL returned 404.
+# Use Fedora 42 Cloud Base Vagrant boxes (provider-specific).
+f42_libvirt_box_url = 'https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42-1.1.x86_64.vagrant.libvirt.box'
+f42_virtualbox_box_url = 'https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-VirtualBox-42-1.1.x86_64.vagrant.virtualbox.box'
+
 Vagrant.configure(2) do |config|
-  config.hostmanager.enabled = true
-  config.hostmanager.manage_host = true
-  config.hostmanager.manage_guest = true
+  if config.respond_to?(:hostmanager)
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+  end
 
   config.vm.define "badges" do |badges|
-    badges.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-38-1.6.x86_64.vagrant-libvirt.box"
-    badges.vm.box = "f38-cloud-libvirt"
     badges.vm.hostname = "badges.tinystage.test"
 
-    badges.vm.synced_folder '.', '/vagrant', type: "sshfs"
-    badges.vm.synced_folder ".", "/home/vagrant/tahrir", type: "sshfs"
-    # badges.vm.synced_folder "../tahrir-api", "/home/vagrant/tahrir-api", type: "sshfs"
-
-    badges.vm.provider :libvirt do |libvirt|
+    badges.vm.provider :libvirt do |libvirt, override|
       libvirt.cpus = 2
       libvirt.memory = 2048
+
+      # Provider-specific base box + synced folder mechanism.
+      override.vm.box = 'f42-cloud-libvirt'
+      override.vm.box_url = f42_libvirt_box_url
+      override.vm.synced_folder '.', '/vagrant', type: 'sshfs'
+      override.vm.synced_folder '.', '/home/vagrant/tahrir', type: 'sshfs'
+    end
+
+    badges.vm.provider :virtualbox do |vb, override|
+      vb.cpus = 2
+      vb.memory = 2048
+
+      # Default VirtualBox shared-folder support works on macOS/Windows without
+      # requiring sshfs.
+      override.vm.box = 'f42-cloud-virtualbox'
+      override.vm.box_url = f42_virtualbox_box_url
+      override.vm.synced_folder '.', '/vagrant', type: 'virtualbox'
+      override.vm.synced_folder '.', '/home/vagrant/tahrir', type: 'virtualbox'
     end
 
     badges.vm.provision "ansible" do |ansible|
@@ -27,5 +46,4 @@ Vagrant.configure(2) do |config|
       ansible.verbose = true
     end
   end
-
 end

--- a/tahrir/endpoints/admin/authorizations.py
+++ b/tahrir/endpoints/admin/authorizations.py
@@ -31,11 +31,9 @@ def add_authorization():
     if not result:
         return abort(400, "Failed to add authorization")
 
-    return jsonify(
-        {
-            "message": f"Badge {data.get(required_fields[0])!r} authorized to {data.get(required_fields[1])!r}"
-        }
-    ), 201
+    badge_id = data.get(required_fields[0])
+    user = data.get(required_fields[1])
+    return jsonify({"message": f"Badge {badge_id!r} authorized to {user!r}"}), 201
 
 
 @bp.route("/api/admin/authorization", methods=["DELETE"])
@@ -64,8 +62,6 @@ def remove_authorization():
     if not result:
         return abort(404, "Authorization not found or failed to remove")
 
-    return jsonify(
-        {
-            "message": f"Badge {data.get(required_fields[0])!r} authorization revoked from {data.get(required_fields[1])!r}"
-        }
-    ), 200
+    badge_id = data.get(required_fields[0])
+    user = data.get(required_fields[1])
+    return jsonify({"message": f"Badge {badge_id!r} authorization revoked from {user!r}"}), 200


### PR DESCRIPTION
## Summary
Fix Vagrant so contributors can run `vagrant up` on macOS/Windows and avoid the Fedora 38 404.

This updates the Vagrant setup to:
- use provider-appropriate Fedora 42 Vagrant boxes
- select the correct synced-folder mechanism per provider
- avoid requiring the `vagrant-hostmanager` plugin

Closes #831

## What changed
- Provider-specific base images + downloads:
  - `libvirt` provider uses Fedora 42 libvirt box
  - `virtualbox` provider uses Fedora 42 VirtualBox box
- Provider-specific synced folders:
  - `libvirt`: uses `sshfs` for `/vagrant` and `/home/vagrant/tahrir`
  - `virtualbox`: uses VirtualBox shared folders for `/vagrant` and `/home/vagrant/tahrir`
- `hostmanager` configuration is now optional:
  - if the `vagrant-hostmanager` plugin is not installed, Vagrant won’t error with “Unknown configuration section `hostmanager`”

## Testing
On macOS Intel with VirtualBox:
- `vagrant up --provider=virtualbox`
- VM boots successfully, shared folders mount to `/vagrant` and `/home/vagrant/tahrir`
- `vagrant provision` runs Ansible provisioning once Ansible is installed on the host

## Notes
- If host Ansible is not installed, provisioning fails with “The Ansible software could not be found”.