### PR TITLE
fix: allow cache reconfiguration between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,11 @@ def app_config(tmpdir):
         TAHRIR_ADMIN_GROUPS=["admin"],
         OIDC_ENABLED=False,
         OIDC_TESTING_PROFILE={"nickname": "test-user", "groups": ["admin"]},
+        CACHE={
+            "backend": "dogpile.cache.null",
+            "expiration_time": 10000,
+            "replace_existing_backend": True,  # fix: allow reconfiguring cache between tests
+        },
     )
 
 


### PR DESCRIPTION
## fix: Allow cache reconfiguration between tests

Fixes #857 

### Problem
Running `pytest tests/` caused all tests using the `app` fixture to fail after the first test with:
```
dogpile.cache.exception.RegionAlreadyConfigured
```
The `dogpile.cache` region is a module-level singleton. Each test creates a fresh app instance which tries to reconfigure the cache, but the second call raises an error.

### Fix
Added `replace_existing_backend=True` to the `CACHE` config in `conftest.py`. This is the flag dogpile.cache itself provides for 
exactly this use case.

### Result
Before: `1 passed, 5 errors` (when running multiple tests)  
After: `11 passed, 0 failures` 