### PR TITLE
Harden /award_from_csv validation and add backend tests

### DIFF
--- a/tahrir/views/admin.py
+++ b/tahrir/views/admin.py
@@ -1,3 +1,5 @@
+import csv
+import io
 from datetime import datetime
 
 from flask import abort, current_app, flash, g, redirect, render_template, request, url_for
@@ -183,41 +185,87 @@ def admin():
 @oidc.require_login
 @require_admin
 def award_from_csv():
-    csv_file = request.files["csv-file"]
-    successful_awards = 0
-    """TODO: We need some validation here, and flash
-    a message whether the awards were successful or not.
-    This should be added at the same time that flash
-    messages are added to the admin panel."""
-    awards = dict()  # str(badge_id) : str(person_email)
-    for line in csv_file:
-        values = line.split(",")
-        """Through the following if statement, it doesn't matter
-        if the line has been entered as "email, badge" or
-        "badge, email". The awards dict will be normalized
-        to be "badge, email". This code assumes that one of the
-        two values will be a valid email address."""
-        if values[0].find("@") == -1:
-            # If there is no @ sign in the first value, it is the badge id.
-            awards[values[1].strip()] = values[0].strip()
-        else:
-            # If there is an @ sign in the first value, it is the email.
-            awards[values[0].strip()] = values[1].strip()
+    # Accepted optional header names (case-insensitive):
+    # email/person_email,badge/badge_id
+    expected_header_values = {"email", "person_email", "badge", "badge_id"}
 
-    for email, badge_id in awards.items():
+    csv_file = request.files.get("csv-file")
+    if not csv_file or not csv_file.filename:
+        flash("No file was uploaded.")
+        return redirect(url_for("tahrir.admin"))
+
+    if not csv_file.filename.lower().endswith(".csv"):
+        flash("Invalid file type. Please upload a .csv file.")
+        return redirect(url_for("tahrir.admin"))
+
+    try:
+        decoded = csv_file.stream.read().decode("utf-8-sig")
+    except UnicodeDecodeError:
+        flash("Invalid file encoding. Please upload a UTF-8 CSV file.")
+        return redirect(url_for("tahrir.admin"))
+
+    if not decoded.strip():
+        flash("The uploaded CSV file is empty.")
+        return redirect(url_for("tahrir.admin"))
+
+    reader = csv.reader(io.StringIO(decoded))
+    successful_awards = 0
+    skipped_existing = 0
+    invalid_badge = 0
+    invalid_rows = 0
+    awards = set()  # {(email, badge_id)}
+    for row_num, values in enumerate(reader, start=1):
+        normalized = [value.strip() for value in values]
+        if not any(normalized):
+            continue
+
+        # Allow a header row only when both cells look like known column names.
+        if row_num == 1 and len(normalized) == 2:
+            first, second = normalized[0].lower(), normalized[1].lower()
+            if first in expected_header_values and second in expected_header_values:
+                continue
+
+        if len(normalized) != 2:
+            invalid_rows += 1
+            continue
+
+        first, second = normalized
+        if "@" in first and "@" not in second:
+            email, badge_id = first, second
+        elif "@" in second and "@" not in first:
+            email, badge_id = second, first
+        else:
+            invalid_rows += 1
+            continue
+
+        awards.add((email, badge_id))
+
+    for email, badge_id in awards:
         # First, if the person doesn't exist, we automatically
         # create the person in this special case.
         if not g.tahrirdb.person_exists(email=email):
             g.tahrirdb.add_person(email)
         # Second, if the badge exists and the person has yet
         # to be awarded it, give it to them.
-        if g.tahrirdb.badge_exists(badge_id):
-            if not g.tahrirdb.assertion_exists(badge_id, email):
-                # The None will default to datetime.now().
-                g.tahrirdb.add_assertion(badge_id, email, None)
-                successful_awards += 1
+        if not g.tahrirdb.badge_exists(badge_id):
+            invalid_badge += 1
+            continue
 
-    flash(f"Successfully awarded {successful_awards} badges.")
+        if g.tahrirdb.assertion_exists(badge_id, email):
+            skipped_existing += 1
+            continue
+
+        # None will default to datetime.now(). (the current date and time)
+        g.tahrirdb.add_assertion(badge_id, email, None)
+        successful_awards += 1
+
+    flash(
+        "CSV import complete: "
+        f"{successful_awards} awarded, "
+        f"{skipped_existing} already existed, "
+        f"{invalid_badge} invalid badge rows, "
+        f"{invalid_rows} invalid rows."
+    )
     return redirect(url_for("tahrir.admin"))
 
 

--- a/tests/test_admin_award_from_csv.py
+++ b/tests/test_admin_award_from_csv.py
@@ -1,0 +1,117 @@
+import io
+import os
+from uuid import uuid4
+
+import pytest
+from tahrir_api.utils import get_db_manager_from_uri
+
+from tahrir.app import create_app
+from tahrir.database import db
+
+
+@pytest.fixture(scope="session")
+def app_config(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("db")
+    db_path = os.path.join(tmpdir, "database.sqlite")
+    return dict(
+        TESTING=True,
+        DEBUG=True,
+        WTF_CSRF_ENABLED=False,
+        SECRET_KEY=b"not-secret",
+        SESSION_COOKIE_SECURE=False,
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{db_path}",
+        TAHRIR_ADMIN_GROUPS=["admin"],
+        OIDC_ENABLED=False,
+        OIDC_TESTING_PROFILE={"nickname": "test-user", "groups": ["admin"]},
+    )
+
+
+@pytest.fixture(scope="session")
+def app(app_config):
+    previous_flask_config = os.environ.pop("FLASK_CONFIG", None)
+    app = create_app(app_config)
+    with app.app_context():
+        db_manager = get_db_manager_from_uri(app.config["SQLALCHEMY_DATABASE_URI"])
+        db_manager.create()
+    yield app
+    db.Session.close()
+    if previous_flask_config is not None:
+        os.environ["FLASK_CONFIG"] = previous_flask_config
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as test_client:
+        with app.app_context():
+            yield test_client
+
+
+@pytest.fixture
+def dummy_issuer(app):
+    tahrir_db = db.get_db()
+    unique = str(uuid4())[:8]
+    return tahrir_db.add_issuer(
+        origin=f"testing-{unique}",
+        name=f"test-issuer-{unique}",
+        org="testing",
+        contact="testing",
+    )
+
+
+def _upload_csv(client, payload: bytes, filename: str = "awards.csv"):
+    return client.post(
+        "/award_from_csv",
+        data={"csv-file": (io.BytesIO(payload), filename)},
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+
+def test_award_from_csv_rejects_non_csv_extension(client):
+    response = _upload_csv(client, b"user@example.com,test-badge\n", filename="awards.txt")
+
+    assert response.status_code == 200
+    assert "Invalid file type. Please upload a .csv file." in response.get_data(as_text=True)
+
+
+def test_award_from_csv_rejects_invalid_encoding(client):
+    response = _upload_csv(client, b"\xff\xfe\x00\x00", filename="awards.csv")
+
+    assert response.status_code == 200
+    assert "Invalid file encoding. Please upload a UTF-8 CSV file." in response.get_data(
+        as_text=True
+    )
+
+
+def test_award_from_csv_awards_and_skips_invalid_rows(app, client, dummy_issuer):
+    tahrir_db = db.get_db()
+    badge_id = tahrir_db.add_badge(
+        name="Test Badge",
+        image="dummy-image",
+        desc="dummy-desc",
+        criteria="dummy-criteria",
+        issuer_id=dummy_issuer,
+    )
+
+    csv_payload = (
+        b"email,badge_id\n"
+        + f"user1@example.com,{badge_id}\n".encode()
+        + f"{badge_id},user2@example.com\n".encode()
+        + f"user1@example.com,{badge_id}\n".encode()
+        + b"bad-row-without-comma\n"
+        + b"no-at-sign,badge-id\n"
+        + b"user3@example.com,missing-badge\n"
+    )
+
+    response = _upload_csv(client, csv_payload)
+    response_text = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert (
+        "CSV import complete: 2 awarded, 0 already existed, 1 invalid badge rows, 2 invalid rows."
+        in response_text
+    )
+
+    assert tahrir_db.assertion_exists(badge_id, "user1@example.com")
+    assert tahrir_db.assertion_exists(badge_id, "user2@example.com")
+    assert not tahrir_db.assertion_exists("missing-badge", "user3@example.com")


### PR DESCRIPTION
Closes #859

## What changed

This PR hardens the legacy admin bulk award flow at `/award_from_csv` and adds backend test coverage for the new validation behavior.

### Backend validation improvements
Updated `tahrir/views/admin.py` to enforce strict CSV handling:

- Require uploaded file presence.
- Require `.csv` extension.
- Require UTF-8 decodable content (`utf-8-sig` supported).
- Reject empty files.
- Parse using Python `csv` module instead of manual `split(",")`.
- Validate row shape (exactly 2 columns).
- Track and report summary counts:
  - awarded
  - already existed
  - invalid badge rows
  - invalid rows


AI disclosure:
I used DeepSeek for writing assistance on issue/PR text and phrasing.
I reviewed, edited, and validated all final code changes, tests, and commit content myself, and I take full responsibility for the contribution.
