### PR TITLE
feat: Replace badge builder with WTForms and Jinja2 YAML generation

### DIFF
--- a/tahrir/forms.py
+++ b/tahrir/forms.py
@@ -1,0 +1,43 @@
+from flask_wtf import FlaskForm
+from wtforms import SelectField, StringField, TextAreaField
+from wtforms.validators import Optional
+
+
+DEFAULT_PREVIOUS = """\
+filter:
+  topics:
+    - message.topic
+  users:
+    - recipient
+  rows_per_page: 0
+operation: count"""
+
+CONDITION_CHOICES = [
+    ("", "-- Select a condition --"),
+    ("greater than or equal to: 1", "≥ 1"),
+    ("greater than or equal to: 5", "≥ 5"),
+    ("greater than or equal to: 10", "≥ 10"),
+    ("greater than or equal to: 25", "≥ 25"),
+    ("greater than or equal to: 50", "≥ 50"),
+    ("greater than or equal to: 100", "≥ 100"),
+]
+
+
+class BadgeBuilderForm(FlaskForm):
+    badge_name = StringField("Badge Name", validators=[Optional()])
+    badge_description = StringField("Badge Description", validators=[Optional()])
+    badge_creator = StringField("Badge Creator", validators=[Optional()])
+    discussion = StringField("Discussion URL", validators=[Optional()])
+    image = StringField("Image URL", validators=[Optional()])
+    issuer = StringField("Issuer ID", validators=[Optional()])
+    trigger_topic = StringField("Trigger Topic", validators=[Optional()])
+    condition = SelectField(
+        "Condition",
+        choices=CONDITION_CHOICES,
+        validators=[Optional()],
+    )
+    previous = TextAreaField(
+        "Previous Value",
+        validators=[Optional()],
+        default=DEFAULT_PREVIOUS,
+    )

--- a/tahrir/templates/builder.html
+++ b/tahrir/templates/builder.html
@@ -1,13 +1,12 @@
 {% extends '_base.html' %}
 
 {% block body %}
-<script type="text/javascript" src="{{ url_for('static', filename='/js/builder.js') }}"></script>
 <div class="page">
   <div class="grid-100">
     <h1 class="section-header">Badge Builder</h1>
     <div class="padded-content">
       <p>
-        Badges can be awarded automatically when certain critera
+        Badges can be awarded automatically when certain criteria
         are met. This is done with data collected by
         <a href="https://github.com/fedora-infra/datanommer">datanommer</a>
         from the
@@ -20,100 +19,97 @@
         This tool may be used by administrators to create badge files
         for new badges, or by regular users to create badge files for
         badges they want to submit to an administrator for
-        consideration. This builder does not submit badges anywhere,
-        it is simply a useful browser tool.
+        consideration. This builder does not submit badges anywhere —
+        it simply generates YAML for your use.
       </p>
     </div>
     <div class="clear"></div>
-    <!-- COLUMN 1 (Left)-->
+
+    <!-- COLUMN 1 (Left) -->
     <div class="grid-50">
       <h3>Badge Builder</h3>
       <form id="builder-form" method="POST">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {{ form.hidden_tag() }}
         <table>
           <tr>
-            <td><label for="badge-name">Badge Name</label></td>
-            <td><input name="badge-name" tabindex="1" /></td>
-            <td><label for="discussion">Discussion URL</label></td>
-            <td><input name="discussion" tabindex="4" /></td>
+            <td>{{ form.badge_name.label }}</td>
+            <td>{{ form.badge_name(tabindex=1) }}</td>
+            <td>{{ form.discussion.label }}</td>
+            <td>{{ form.discussion(tabindex=4) }}</td>
           </tr>
           <tr>
-            <td><label for="badge-description">Badge Description</label></td>
-            <td><input name="badge-description" tabindex="2" /></td>
-            <td><label for="image">Image URL</label></td>
-            <td><input name="image" tabindex="5" /></td>
+            <td>{{ form.badge_description.label }}</td>
+            <td>{{ form.badge_description(tabindex=2) }}</td>
+            <td>{{ form.image.label }}</td>
+            <td>{{ form.image(tabindex=5) }}</td>
           </tr>
           <tr>
-            <td><label for="badge-creator">Badge Creator</label></td>
-            <td>
-              <input name="badge-creator" tabindex="3" value="{{ default_creator if default_creator else '' }}" />
-            </td>
-            <td><label for="issuer">Issuer ID</label></td>
-            <td>
-              <input name="issuer" tabindex="6" value="{{ config['TAHRIR_DEFAULT_ISSUER'] }}" />
-            </td>
+            <td>{{ form.badge_creator.label }}</td>
+            <td>{{ form.badge_creator(tabindex=3) }}</td>
+            <td>{{ form.issuer.label }}</td>
+            <td>{{ form.issuer(tabindex=6) }}</td>
           </tr>
           <tr>
-            <td><label for="trigger-topic">Trigger Topic</label></td>
-            <td><input name="trigger-topic" tabindex="7" /></td>
-            <td><label for="condition">Condition</label></td>
-            <td><input name="condition" tabindex="8" value="greater than or equal to: 10" /></td>
+            <td>{{ form.trigger_topic.label }}</td>
+            <td>{{ form.trigger_topic(tabindex=7) }}</td>
+            <td>{{ form.condition.label }}</td>
+            <td>{{ form.condition(tabindex=8) }}</td>
           </tr>
           <tr>
-            <td>
-              <label for="previous">Previous value</label>
-            </td>
+            <td>{{ form.previous.label }}</td>
             <td colspan="3">
-              <textarea name="previous" cols=40 rows=7>
-filter:
-  topics:
-    - message.topic
-  users:
-    - recipient
-  rows_per_page: 0
-operation: count
-</textarea>
+              {{ form.previous(cols=40, rows=7) }}
             </td>
+          </tr>
           <tr>
             <td colspan="4">
-              <input name="generate" type="submit" action="{{ url_for('tahrir.builder') }}" value="Generate" />
+              <input name="generate" type="submit" value="Generate" />
             </td>
           </tr>
         </table>
       </form>
     </div>
-    <!-- COLUMN 2 (Right)-->
+
+    <!-- COLUMN 2 (Right) -->
     <div class="grid-50">
-  <!--- COMMENT OUT THE PREVIEW AREA FOR NOW
-      <h3>Preview</h3>
-  <p>Preview will work only if JavaScript is enabled.</p>
-  <form id="preview-options-form">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    <table>
-      <tr><td>
-          <label for="read-only">Preview is read only?
-            <span class="sublabel">Any changes will be
-              undone if any of the above fields are altered.</span>
-          </label></td>
-        <td><input type="checkbox" name="read-only" checked="checked"/></td></r>
-</table>
-</form>
-<textarea id="preview"
-          form="builder-form" readonly="readonly"
-          rows="25" cols="80"></textarea>
+      <h3>Output</h3>
+      {% if form.is_submitted() and form.badge_name.data %}
+      <textarea rows="30" cols="80">
+%YAML 1.2
+---
+
+# Badge metadata
+name:           {{ form.badge_name.data | default('') }}
+description:    {{ form.badge_description.data | default('') }}
+creator:        {{ form.badge_creator.data | default('') }}
+
+# Discussion link
+discussion:     {{ form.discussion.data | default('') }}
+
+# Badge image
+image_url:      {{ form.image.data | default('') }}
+
+# Issuer
+issuer_id:      {{ form.issuer.data | default('') }}
+
+# Trigger — only run the costly check when this topic arrives
+trigger:
+  topic:        {{ form.trigger_topic.data | default('') }}
+
+# Award condition
+condition:
+  {{ form.condition.data | default('') }}
+
+# Previous message check
+previous:
+{{ form.previous.data | default('') }}
+      </textarea>
+      {% else %}
+      <textarea rows="30" cols="80">Badge YAML will appear here after you click Generate.</textarea>
+      {% endif %}
+    </div>
+
+    <div class="clear spacer"></div>
+  </div>
 </div>
-</div>
-
-END COMMENTING OUT PREVIEW AREA -->
-
-  <h3>Output</h3>
-  {% if badge_yaml %}
-    <textarea rows="30" cols="80">{{badge_yaml}}</textarea>
-  {% else %}
-    <textarea rows="30" cols="80">Badge YAML will appear here.</textarea>
-  {% endif %}
-
-  <div class="clear spacer"></div>
-</div>
-
 {% endblock %}

--- a/tahrir/utils/badge.py
+++ b/tahrir/utils/badge.py
@@ -139,45 +139,11 @@ def convert_name_to_id(name):
 
     badge_id = name.lower().replace(" ", "-")
     bad = ['"', "'", "(", ")", "*", "&", "?"]
-    replacements = dict(zip(bad, [""] * len(bad)))
+    replacements = dict(zip(bad, [""] * len(bad), strict=False))
     for a, b in replacements.items():
         badge_id = badge_id.replace(a, b)
 
     return badge_id
-
-
-def generate_badge_yaml(postdict):
-    return (
-        "%YAML 1.2\n"
-        "---\n"
-        "\n"
-        "# This is some metadata about the badge.\n"
-        "name:           " + postdict.get("badge-name", default="") + "\n"
-        "description:    " + postdict.get("badge-description", default="") + "\n"
-        "creator:        " + postdict.get("badge-creator", default="") + "\n"
-        "\n"
-        "# This is a link to the discussion about adopting this as\n"
-        "a for-real badge\n"
-        "discussion:     " + postdict.get("discussion", default="") + "\n"
-        "\n"
-        "# A link to the image for the badge.\n"
-        "image_url:      " + postdict.get("image", default="") + "\n"
-        "\n"
-        "# The issuer.\n"
-        "issuer_id:      " + postdict.get("issuer", default="") + "\n"
-        "\n"
-        "# We'll perform our more costly check (defined below)\n"
-        "# only when we receive messages that match this trigger.\n"
-        "trigger:\n"
-        "  topic:        " + postdict.get("trigger-topic", default="") + "\n"
-        "\n"
-        "# Award the badge under these conditions:\n"
-        "condition:\n" + postdict.get("condition", default="") + "\n"
-        "# If the messages matches for the user for the first time, look into previous messages"
-        " to get the count:\n"
-        "previous:\n" + postdict.get("previous", default="") + "\n"
-        "(This section is under construction.)"
-    )
 
 
 def serialize_badges(badges):

--- a/tahrir/views/admin.py
+++ b/tahrir/views/admin.py
@@ -248,9 +248,7 @@ def builder():
     if request.method == "GET":
         # Pre-fill defaults
         if g.oidc_user.person:
-            form.badge_creator.data = (
-                g.oidc_user.person.nickname or g.oidc_user.person.email
-            )
+            form.badge_creator.data = g.oidc_user.person.nickname or g.oidc_user.person.email
         form.issuer.data = current_app.config.get("TAHRIR_DEFAULT_ISSUER", "")
 
     return render_template("builder.html", form=form)

--- a/tahrir/views/admin.py
+++ b/tahrir/views/admin.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from flask import abort, current_app, flash, g, redirect, render_template, request, url_for
 
 from tahrir.app import oidc
-from tahrir.utils.badge import convert_name_to_id, generate_badge_yaml
+from tahrir.utils.badge import convert_name_to_id
 from tahrir.utils.user import require_admin
 
 from . import blueprint as bp
@@ -241,17 +241,16 @@ def add_tag(request):
 
 @bp.route("/builder", methods=["GET", "POST"])
 def builder():
-    # get default creator field
-    default_creator = None
-    if g.oidc_user.person:
-        default_creator = g.oidc_user.person.nickname or g.oidc_user.person.email
+    from tahrir.forms import BadgeBuilderForm
 
-    badge_yaml = None
-    if request.method == "POST":
-        badge_yaml = generate_badge_yaml(request.form)
+    form = BadgeBuilderForm()
 
-    return render_template(
-        "builder.html",
-        default_creator=default_creator,
-        badge_yaml=badge_yaml,
-    )
+    if request.method == "GET":
+        # Pre-fill defaults
+        if g.oidc_user.person:
+            form.badge_creator.data = (
+                g.oidc_user.person.nickname or g.oidc_user.person.email
+            )
+        form.issuer.data = current_app.config.get("TAHRIR_DEFAULT_ISSUER", "")
+
+    return render_template("builder.html", form=form)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,4 +1,3 @@
-
 """Test tahrir.views.admin.builder"""
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,63 @@
+
+"""Test tahrir.views.admin.builder"""
+
+
+def test_builder_get(client):
+    """Test that the badge builder page loads successfully."""
+    response = client.get("/builder")
+    assert response.status_code == 200
+
+
+def test_builder_get_contains_form(client):
+    """Test that the builder page renders the WTForms form fields."""
+    response = client.get("/builder")
+    html = response.get_data(as_text=True)
+    assert "Badge Name" in html
+    assert "Badge Description" in html
+    assert "Condition" in html
+    assert "Trigger Topic" in html
+
+
+def test_builder_get_condition_is_dropdown(client):
+    """Test that the Condition field renders as a select dropdown."""
+    response = client.get("/builder")
+    html = response.get_data(as_text=True)
+    assert "<select" in html
+    assert "greater than or equal to" in html
+
+
+def test_builder_post_generates_yaml(client):
+    """Test that submitting the form generates YAML output."""
+    response = client.post(
+        "/builder",
+        data={
+            "badge_name": "Test Badge",
+            "badge_description": "A test badge",
+            "badge_creator": "tester",
+            "discussion": "",
+            "image": "",
+            "issuer": "fedora-project",
+            "trigger_topic": "org.fedora.test",
+            "condition": "greater than or equal to: 1",
+            "previous": "",
+            "generate": "Generate",
+        },
+    )
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Test Badge" in html
+    assert "%YAML 1.2" in html
+
+
+def test_builder_post_empty_shows_placeholder(client):
+    """Test that submitting without a badge name shows placeholder text."""
+    response = client.post(
+        "/builder",
+        data={
+            "badge_name": "",
+            "generate": "Generate",
+        },
+    )
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Badge YAML will appear here" in html


### PR DESCRIPTION

## feat: Replace badge builder form with WTForms and Jinja2 YAML generation

Closes #520 

### Changes
- Added `BadgeBuilderForm` in `tahrir/forms.py` using Flask-WTF
- `Condition` field is now a `SelectField` dropdown instead of free text input
- YAML generation moved from Python string templating in generate_badge_yaml()` to Jinja2 template conditionals
- Removed `generate_badge_yaml()` from `tahrir/utils/badge.py`
- Form fields are no longer reused on the result page
- CSRF protection handled properly via `form.hidden_tag()`
- Removed unused `builder.js` script reference
- Added tests