### PR TITLE
Remove unreachable dead code in avatar utility

### DIFF
--- a/tahrir/utils/avatar.py
+++ b/tahrir/utils/avatar.py
@@ -6,13 +6,6 @@ from flask import current_app
 from tahrir.cache import cache
 
 
-libravatar = None
-try:
-    import libravatar
-except ImportError:
-    pass
-
-
 @cache.cache_on_arguments()
 def get_avatar(email: str, size):
     default = current_app.config["TAHRIR_DEFAULT_AVATAR"]
@@ -33,21 +26,7 @@ def get_avatar(email: str, size):
     # hash = md5(email).hexdigest()
     hash = sha256(email.encode("utf-8")).hexdigest()
 
-    # TODO This next line is temporary and can be removed.  We do
-    # libravatar ourselves here by hand to avoid pyDNS issues on epel6.
-    # Once those are resolved we can use pylibravatar again.
     return f"https://seccdn.libravatar.org/avatar/{hash}?{query}"
-
-    gravatar_url = f"https://secure.gravatar.com/avatar/{hash}?{query}"
-
-    if libravatar:
-        return libravatar.libravatar_url(
-            email=email,
-            size=size,
-            default=gravatar_url,
-        )
-    else:
-        return gravatar_url
 
 
 def as_avatar(value, size):


### PR DESCRIPTION
## Summary

- Remove unreachable code (lines 41–50) in `get_avatar()` that could never execute due to an early `return` on line 39
- Remove unused `libravatar` import (lines 9–13) that was only referenced in the dead code block
- Remove outdated TODO comment referencing a pyDNS/epel6 workaround that is no longer relevant
fixes #890 task 6 of #904
No use of AI for this pr