### PR TITLE
Remove debug print() statement from json_report_year view

### DIFF
--- a/tahrir/views/report.py
+++ b/tahrir/views/report.py
@@ -145,7 +145,6 @@ def json_report_year(year=None, week=None, month=None, day=None):
         # Weekly report
         start = get_start_week(year, month, day)
         stop = start + timedelta(days=6)
-        print("Start: ", start, " End: ", stop)
     elif day is not None:
         # Daily report
         start = date(year, month, day)


### PR DESCRIPTION
## Summary

- Remove leftover debug `print()` statement from `json_report_year` view in `tahrir/views/report.py` (line 148)
- This `print("Start: ", start, " End: ", stop)` was polluting server logs on every weekly leaderboard request to `/json/report/y/<year>/m/<month>/d/<day>/week`

- Run the application and visit `/json/report/y/2026/m/3/d/28/week`
- Verify the JSON response returns correctly
- Verify no debug output appears in the server console

Fixes #872 