### PR TITLE
Remove dead code in avatar utility

### DIFF
--- a/tahrir/utils/avatar.py
+++ b/tahrir/utils/avatar.py
@@ -6,13 +6,6 @@ from flask import current_app
 from tahrir.cache import cache
 
 
-libravatar = None
-try:
-    import libravatar
-except ImportError:
-    pass
-
-
 @cache.cache_on_arguments()
 def get_avatar(email: str, size):
     default = current_app.config["TAHRIR_DEFAULT_AVATAR"]
@@ -28,26 +21,9 @@ def get_avatar(email: str, size):
 
     query = urllib.parse.urlencode(query)
 
-    # Use md5 for emails, and sha256 for openids.
-    # We're really using openids, so...
-    # hash = md5(email).hexdigest()
     hash = sha256(email.encode("utf-8")).hexdigest()
 
-    # TODO This next line is temporary and can be removed.  We do
-    # libravatar ourselves here by hand to avoid pyDNS issues on epel6.
-    # Once those are resolved we can use pylibravatar again.
     return f"https://seccdn.libravatar.org/avatar/{hash}?{query}"
-
-    gravatar_url = f"https://secure.gravatar.com/avatar/{hash}?{query}"
-
-    if libravatar:
-        return libravatar.libravatar_url(
-            email=email,
-            size=size,
-            default=gravatar_url,
-        )
-    else:
-        return gravatar_url
 
 
 def as_avatar(value, size):


### PR DESCRIPTION

Part of #904 

Removes unreachable dead code from `tahrir/utils/avatar.py`.

## Changes
- Remove unreachable code (lines 41-50) after the early `return` on line 39 in `get_avatar()`
- Remove unused `libravatar` import block that was only referenced in the dead code
- Remove outdated TODO comment referencing a pyDNS/epel6 workaround

## Verification
- `get_avatar()` and `as_avatar()` functions remain intact
- No React frontend code or API endpoints are affected
- The function behaviour is unchanged, the return statement on line 39 was already the only reachable exit point
