### PR TITLE
cleanup: remove dead code in tahrir/utils/avatar.py

### DIFF
--- a/tahrir/utils/avatar.py
+++ b/tahrir/utils/avatar.py
@@ -5,14 +5,6 @@ from flask import current_app
 
 from tahrir.cache import cache
 
-
-libravatar = None
-try:
-    import libravatar
-except ImportError:
-    pass
-
-
 @cache.cache_on_arguments()
 def get_avatar(email: str, size):
     default = current_app.config["TAHRIR_DEFAULT_AVATAR"]
@@ -33,26 +25,11 @@ def get_avatar(email: str, size):
     # hash = md5(email).hexdigest()
     hash = sha256(email.encode("utf-8")).hexdigest()
 
-    # TODO This next line is temporary and can be removed.  We do
-    # libravatar ourselves here by hand to avoid pyDNS issues on epel6.
-    # Once those are resolved we can use pylibravatar again.
     return f"https://seccdn.libravatar.org/avatar/{hash}?{query}"
 
-    gravatar_url = f"https://secure.gravatar.com/avatar/{hash}?{query}"
-
-    if libravatar:
-        return libravatar.libravatar_url(
-            email=email,
-            size=size,
-            default=gravatar_url,
-        )
-    else:
-        return gravatar_url
-
-
+    
 def as_avatar(value, size):
     return get_avatar(value, size=size)
-
 
 def hash_email(email):
     if not email:


### PR DESCRIPTION
Part of remove legacy Jinja2 frontend and associated dead code #904
I cleaned up dead code in tahrir/utils/avatar.py

File: tahrir/utils/avatar.py
Lines 41–50 are unreachable due to an early return on line 39
 the dead code and the associated TODO comment on lines 36–3 were removed