### PR TITLE
Hydration error warning caused by nested hyperlink HTML elements

### DIFF
--- a/frontend/src/routes/homepage.jsx
+++ b/frontend/src/routes/homepage.jsx
@@ -40,6 +40,14 @@ export default function Homepage() {
     }
   };
 
+  // Using onClick instead of link to avoid nested <a> tags (hydration error).
+  // Trade-off: right-click "Open in new tab" will not work on award items.
+  const handleAwardsClick = (e, path) => {
+    if(!e.target.closest('a')) {
+      navigate(path);
+    }
+  };
+
   // Show or Hide LoadNote
   useEffect(() => {
     if (isLoading) {
@@ -195,7 +203,7 @@ export default function Homepage() {
                     </>
                   }
                   shot={item.person?.mail ? portraitProvider(item.person.mail, 45) : null}
-                  link={`/identity/${item.person?.nickname || ""}`}
+                  onClick={(e) => {handleAwardsClick(e, `/identity/${item.person?.nickname || ""}`)}}
                 />
               ))}
             </ListGroup>


### PR DESCRIPTION
## Summary

- Hydration error warning pops up every time the home page is loaded, This is caused by nesting an hyperlink element e.g `<a>` in another. Many reusable components in the modern packages often have different components implementing an HTML hyperlink element in them. When these components are not used properly it could result into an hydration error. 

- In the tahrir project, this error occurs at `tahrir/frontend/src/routes/homepage.jsx` where we have a `<Link>` component nested under a `<VertItem>` component which also contains a `<Link>` component.

Fixes #903 
**No AI tools used**

## Changes

- The `<VertItem>` component has been provisioned with an `onClick` option which can be used in place of the `link` option in this case. 

- I created a `handleAwardsClicks` function to satisy the `onClick` event in the `<VertItem>` component. Within the function, navigation is properly handled by the `useNavigation` hook from react router.

<img width="1920" height="933" alt="Screenshot From 2026-04-01 04-14-01" src="https://github.com/user-attachments/assets/839b0886-8be3-48b6-aa82-dfd4592343fb" />