### PR TITLE
Remove legacy Jinja2 view functions

### DIFF
--- a/tahrir/views/badge.py
+++ b/tahrir/views/badge.py
@@ -76,8 +76,6 @@ def award():
         g.tahrirdb.add_assertion(badge.id, user.email, None)
         flash(f"User {user.nickname} has been awarded the {badge.id} badge")
 
-    # COMMENT
-
     return redirect(url_for("tahrir.badge", badge_id=badge.id))
 
 

--- a/tahrir/views/explore.py
+++ b/tahrir/views/explore.py
@@ -109,10 +109,6 @@ def explore_badges_rss():
 @bp.route("/json/rarities", methods=["GET"])
 @bp.route("/json/rarities/<rare>", methods=["GET"])
 def json_rarities(rare=None):
-    """
-    Endpoint that reads and delivers the accolade rarities
-    """
-
     data = {}
     try:
         with open(os.path.join(current_app.static_folder, "rarities.json")) as file:


### PR DESCRIPTION

Part of #904 (task 2)

## Remove legacy view functions that render Jinja2 templates

Directory: tahrir/views/

Views that render legacy templates: index, about, user, diff, badge, badge_full, leaderboard, report, explore, explore_badges, admin, builder, thingiview, assertion_widget, tags

AI tooling used: Claude (Anthropic) was used to assist with identifying which view functions to remove/keep..