### PR TITLE
docs: add DCO sign-off instructions in Contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -39,3 +39,25 @@ To quickly start hacking on Tahrir, we provide a local setup.
    ```
 
 3. Tahrir frontend should now be available on [http://localhost:5173/](http://localhost:5173/). The logs are in `devel/run`. You can restart the frontend and/or the backend using `supervisorctl`.
+
+### Commit Sign-off (DCO)
+
+All commits must be signed to comply with the Developer Certificate of Origin (DCO). Pull requests without this sign-off might be rejected.
+
+When committing changes in your local branch, add the -s flag to the git commit command:
+
+```shell
+git commit -s -m "YOUR_COMMIT_MESSAGE"
+```
+
+This creates a signed commit with an additional line:
+
+```shell
+Signed-off-by: Your Name <your_name@email.com>
+```
+
+For verifying your commit signature, you can check the log using below command:
+
+```shell
+git log -1
+```


### PR DESCRIPTION
## Description

Adds a section explaining how to include a DCO sign-off (`Signed-off-by`) in commits.

## Motivation

While contributing, I noticed that commit sign-off (DCO) is required but not mentioned in the contributing guidelines. This can lead to confusion and rejected pull requests for new contributors, and may also increase the review overhead for maintainers.

This change adds clear instructions to help contributors follow the expected workflow.

## Changes

- Added "Commit Sign-off (DCO)" section under Guidelines
- Included command usage (`git commit -s`)
- Added a quick way to verify sign-off

## Checklist

- [x] Documentation update only
- [x] No code changes

Note: (I'm not an Outreachy Contributor ✌🏻)