### PR TITLE
Refactor: Replace hardcoded email domain with config variable

### DIFF
--- a/tahrir/endpoints/admin/assertions.py
+++ b/tahrir/endpoints/admin/assertions.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from flask import abort, g, jsonify, request
+from flask import abort, current_app, g, jsonify, request
 
 from ...app import csrf, oidc
 from ...utils.user import require_admin
@@ -26,8 +26,7 @@ def create_assertion():
     badge_id = data.get("badge_id")
     username = data.get("username")
 
-    # TODO: Modularize this to variable
-    person_email = f"{username}@fedoraproject.org"
+    person_email = f"{username}@{current_app.config['TAHRIR_EMAIL_DOMAIN']}"
 
     issued_on = data.get("issued_on")
     if issued_on is not None:
@@ -72,8 +71,7 @@ def remove_assertion():
     badge_id = data.get("badge_id")
     username = data.get("username")
 
-    # TODO: Modularize this to variable
-    person_email = f"{username}@fedoraproject.org"
+    person_email = f"{username}@{current_app.config['TAHRIR_EMAIL_DOMAIN']}"
 
     result = g.tahrirdb.remove_assertion(
         badge_id=badge_id,

--- a/tahrir/endpoints/admin/authorizations.py
+++ b/tahrir/endpoints/admin/authorizations.py
@@ -1,4 +1,4 @@
-from flask import abort, g, jsonify, request
+from flask import abort, current_app, g, jsonify, request
 
 from ...app import csrf, oidc
 from ...utils.user import require_admin
@@ -25,7 +25,7 @@ def add_authorization():
     # THIS WORKAROUND IS TEMPORARY AND TAHRIR-API WOULD BE CHANGED TO ACCEPT JUST USERNAME
     result = g.tahrirdb.add_authorization(
         badge_id=data.get(required_fields[0]),
-        person_email=data.get(required_fields[1]) + "@fedoraproject.org",
+        person_email=f"{data.get(required_fields[1])}@{current_app.config['TAHRIR_EMAIL_DOMAIN']}",
     )
 
     if not result:
@@ -33,7 +33,10 @@ def add_authorization():
 
     return jsonify(
         {
-            "message": f"Badge {data.get(required_fields[0])!r} authorized to {data.get(required_fields[1])!r}"
+            "message": (
+                f"Badge {data.get(required_fields[0])!r} "
+                f"authorized to {data.get(required_fields[1])!r}"
+            )
         }
     ), 201
 
@@ -58,7 +61,7 @@ def remove_authorization():
     # THIS WORKAROUND IS TEMPORARY AND TAHRIR-API WOULD BE CHANGED TO ACCEPT JUST USERNAME
     result = g.tahrirdb.delete_authorization(
         badge_id=data.get(required_fields[0]),
-        person_email=data.get(required_fields[1]) + "@fedoraproject.org",
+        person_email=f"{data.get(required_fields[1])}@{current_app.config['TAHRIR_EMAIL_DOMAIN']}",
     )
 
     if not result:
@@ -66,6 +69,9 @@ def remove_authorization():
 
     return jsonify(
         {
-            "message": f"Badge {data.get(required_fields[0])!r} authorization revoked from {data.get(required_fields[1])!r}"
+            "message": (
+                f"Badge {data.get(required_fields[0])!r} "
+                f"authorization revoked from {data.get(required_fields[1])!r}"
+            )
         }
     ), 200

--- a/tahrir/endpoints/admin/invitations.py
+++ b/tahrir/endpoints/admin/invitations.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from flask import abort, g, jsonify, request
+from flask import abort, current_app, g, jsonify, request
 
 from ...app import csrf, oidc
 from ...utils.user import get_person, require_admin
@@ -36,8 +36,7 @@ def add_invitations():
     else:
         return abort(400, "No expires_on timestamp provided")
 
-    # created_by = f"{data.get('issuer_email')}@{current_app.config['TAHRIR_EMAIL_DOMAIN']}"
-    created_by = f"{data.get('issuer_email')}@fedoraproject.org"
+    created_by = f"{data.get('issuer_email')}@{current_app.config['TAHRIR_EMAIL_DOMAIN']}"
     badge_id = data.get("badge_id")
 
     try:


### PR DESCRIPTION
## Summary

This change removes the hardcoded `@fedoraproject.org` email domain and replaces it with the configurable `TAHRIR_EMAIL_DOMAIN` variable across multiple admin endpoints.

## Updated Files

- `admin/assertions.py`
- `admin/authorizations.py`
- `admin/invitations.py`
fixes- #927 