### PR TITLE
Fix user badge history redirect 

### DIFF
--- a/tahrir/views/invitation.py
+++ b/tahrir/views/invitation.py
@@ -28,8 +28,8 @@ def invitation_claim(claim_id):
         )
         flash(f"You have earned {claim.badge_id} badge. Your rank will be updated shortly.")
 
-    # TODO -- return them to a page that auto-exports their badges.
-    return redirect(url_for("tahrir.home"))
+    person = g.oidc_user.person
+    return redirect(f"/identity/{person.nickname or person.id}")
 
 
 @bp.route("/invitations/<claim_id>/qrcode")


### PR DESCRIPTION
Fixes #930 

After claiming a badge via QR code invitation, redirect the user to their badge history page, instead of the home page.

The TODO references "a page that auto-exports their badges". After tracing the React frontend the closest page to this intent is the UserPast component at /identity/:slugdata, which automatically loads and displays the user's full badge history.  

This redirect ensures the user lands on their badge history immediately after claiming a badge rather than the home page.

