### PR TITLE
fix: resolve hydration error in addendum component

### DIFF
--- a/frontend/src/routes/addendum.jsx
+++ b/frontend/src/routes/addendum.jsx
@@ -71,11 +71,7 @@ export default function Addendum() {
                       </p>
                     ),
                     li: ({ children }) => <li className="small">{children}</li>,
-                    img: ({ src, alt }) => (
-                      <div className="text-center">
-                        <img src={src} alt={alt} className="img-fluid" />
-                      </div>
-                    ),
+                    img: ({ src, alt }) => <img src={src} alt={alt} className="img-fluid d-block mx-auto" />,
                     a: ({ href, children }) => (
                       <a href={href} target="_blank" rel="noopener noreferrer">
                         {children}


### PR DESCRIPTION
fixes:#934
I discovered the addendum component responsible for the converting and rendering the addendum.md had a hydration error of a p containing a nested div tag so fixed it by changing the p tag to a div tag.