### PR TITLE
fix: correct decorator order on invitation endpoints

### DIFF
--- a/tahrir/endpoints/admin/invitations.py
+++ b/tahrir/endpoints/admin/invitations.py
@@ -7,10 +7,10 @@ from ...utils.user import get_person, require_admin
 from . import blueprint as bp
 
 
+@bp.route("/api/admin/invitations", methods=["POST"])
 @csrf.exempt
 @oidc.require_login
 @require_admin
-@bp.route("/api/admin/invitations", methods=["POST"])
 def add_invitations():
     """Endpoint to add a new invitation"""
 
@@ -53,10 +53,10 @@ def add_invitations():
     return jsonify({"message": f"Invitation added for Badge {badge_id!r} by {created_by!r}"}), 201
 
 
+@bp.route("/api/admin/invitations", methods=["DELETE"])
 @csrf.exempt
 @oidc.require_login
 @require_admin
-@bp.route("/api/admin/invitations", methods=["DELETE"])
 def remove_invitations():
     """Endpoint to remove an invitation"""
 
@@ -72,10 +72,10 @@ def remove_invitations():
     return jsonify({"message": f"Invitation {data.get('invitation_id')!r} removed successfully"})
 
 
+@bp.route("/api/admin/invitations/<string:user_id>", methods=["GET"])
 @csrf.exempt
 @oidc.require_login
 @require_admin
-@bp.route("/api/admin/invitations/<string:user_id>", methods=["GET"])
 def get_invitations_by_user_id(user_id: str):
     """Endpoint to search for invitations by User ID"""
 

--- a/tahrir/endpoints/invitations.py
+++ b/tahrir/endpoints/invitations.py
@@ -7,9 +7,9 @@ from ..utils.user import get_person
 from . import blueprint as bp
 
 
+@bp.route("/api/invitations/<string:invitation_id>/claim")
 @csrf.exempt
 @oidc.require_login
-@bp.route("/api/invitations/<string:invitation_id>/claim")
 def claim_invitation(invitation_id: str):
     """Action that awards a person a badge after scanning a qrcode."""
 


### PR DESCRIPTION
While going through the code, I noticed that `@bp.route` was placed at the bottom of the decorator stack in both `tahrir/endpoints/invitations.py` and `tahrir/endpoints/admin/invitations.py`. Since Flask registers whichever function `@bp.route` directly wraps at import time, having it below `@csrf.exempt` and `@oidc.require_login` meant the raw unprotected function was being registered instead of the wrapped one, completely bypassing the login and CSRF protection. Moving `@bp.route` to the outermost position fixes this so Flask registers the fully protected version. Ran the full test suite before and after and all 4 tests pass with no regressions.

Fixes #941 