### PR TITLE
fix: add missing session.commit() in opt_out

### DIFF
--- a/tahrir/endpoints/users.py
+++ b/tahrir/endpoints/users.py
@@ -87,6 +87,7 @@ def user_opt_out():
         abort(400, "No data provided")
 
     g.oidc_user.person.opt_out = data.get("opt_out")
+    g.tahrirdb.session.commit()
 
     return jsonify({"message": "User updated successfully"})
 


### PR DESCRIPTION
This PR fixes an issue where the user `opt-out` endpoint updates the opt_out field only in memory without persisting it to the database. As a result, the change is lost after the request completes. The fix adds a missing `g.tahrirdb.session.commit()` call to ensure the updated value is properly saved.