### PR TITLE
Implement a Clear button in the search bar to improve user experience

### DIFF
--- a/frontend/src/components/discover.jsx
+++ b/frontend/src/components/discover.jsx
@@ -10,6 +10,7 @@ import { LookupSpinner } from "./LookupSpinner.jsx";
 export default function Discover() {
   const [findText, makeFindText] = useState("");
   const [dropSeen, makeDropSeen] = useState(false);
+  const [clearSeen, makeClearSeen] = useState(false);
   const dropDown = useRef(null);
   const navigate = useNavigate();
   const doLookup = findText.length >= 4;
@@ -41,6 +42,7 @@ export default function Discover() {
     const text = e.target.value;
     makeFindText(text);
     makeDropSeen(text.trim().length >= 4);
+    makeClearSeen(text.trim().length >= 1);
   };
 
   const handleResult = () => {
@@ -62,6 +64,12 @@ export default function Discover() {
     }
   };
 
+  const handleClear = () => {
+    makeFindText("");
+    makeClearSeen(false);
+    makeDropSeen(false);
+  };
+
   const hasResults = searchResults && (searchResults.badges?.length > 0 || searchResults.users?.length > 0);
 
   return (
@@ -77,6 +85,19 @@ export default function Discover() {
         autoComplete="off"
       />
       {showSpinner && <LookupSpinner />}
+
+      {
+        (!showSpinner && clearSeen) && (
+            <button 
+              type="button"
+              className="position-absolute top-50 translate-middle-y end-0 ps-1 border-0 bg-body"
+              style={{ paddingRight: "0.50rem" }}
+              onClick={handleClear}
+            >
+              &times;
+            </button>
+          )
+      }
 
       {dropSeen && doLookup && (
         <Dropdown.Menu show className="position-absolute w-100 mt-1" style={{ zIndex: 1050 }}>


### PR DESCRIPTION
## Overview

Most browsers don't support the use of 'type=search' in input types which often brings an 'x' button to help users clear their inputs. FIrefox definitely doesn't support the search type, I also tried on a chrome browser it didn't show up then I found out a css style which targets the elements could help show it on chrome, but this wouldn't be a permanent solution. 
A clear button was added to the search bar to improve the UX, and is being handled by a `handleClear` function

close #959 
**No AI tools used**

### Before 
<img width="1651" height="793" alt="Screenshot From 2026-04-09 15-42-42" src="https://github.com/user-attachments/assets/1e572426-cb99-4070-80a8-a76592de053d" />

### After

https://github.com/user-attachments/assets/5f5ded1c-1c63-46c4-9e1f-a8e641be77dc

