### PR TITLE
fix: paginate get_all_assertions in Python

### DIFF
--- a/tahrir/endpoints/assertions.py
+++ b/tahrir/endpoints/assertions.py
@@ -12,7 +12,7 @@ def get_recent_assertions():
     limit = min(request.args.get("limit", 40, type=int), 40)
 
     all_assertions = list(g.tahrirdb.get_all_assertions())
-    assertions = all_assertions[begin:begin + limit]
+    assertions = all_assertions[begin : begin + limit]
     if not assertions:
         return jsonify([])
 

--- a/tahrir/endpoints/assertions.py
+++ b/tahrir/endpoints/assertions.py
@@ -11,7 +11,8 @@ def get_recent_assertions():
     begin = request.args.get("begin", 0, type=int)
     limit = min(request.args.get("limit", 40, type=int), 40)
 
-    assertions = list(g.tahrirdb.get_all_assertions(begin, limit))
+    all_assertions = list(g.tahrirdb.get_all_assertions())
+    assertions = all_assertions[begin:begin + limit]
     if not assertions:
         return jsonify([])
 


### PR DESCRIPTION
Closes #962

While setting up the project locally, the homepage was showing "Resource unavailable" and the browser console showed a 500 error on `/api/assertions?begin=0`.

Turns out `get_all_assertions()` takes no arguments, but `begin` and `limit` were being passed directly to it. Fixed by fetching 
all assertions first and then slicing in Python, which is the same approach already used in `get_assertions_by_badge`.

```python
all_assertions = list(g.tahrirdb.get_all_assertions())
assertions = all_assertions[begin:begin + limit]
```

**Before:** 500 Internal Server Error, homepage fails to load
<img width="960" height="472" alt="Screenshot 2026-04-12 114226" src="https://github.com/user-attachments/assets/8933a460-adbd-4f39-a91b-33091ba5252a" />


**After:** Recent awards load correctly
<img width="960" height="464" alt="Screenshot 2026-04-12 162110" src="https://github.com/user-attachments/assets/3ed70662-a85a-4f11-8842-f1bbf939422a" />
