### PR TITLE
fix: check user auth before fetching API

### DIFF
--- a/frontend/src/features/auth.js
+++ b/frontend/src/features/auth.js
@@ -6,6 +6,9 @@ import { API_BASE_URL } from "./call.js";
 
 export const loadUserData = createAsyncThunk("auth/loadUserData", async () => {
   const user = await userManager.getUser();
+  if (!user || user.expired) {
+    return null;
+  }
   const response = await fetch(API_BASE_URL + "/api/users/", {
     method: "POST",
     headers: {
@@ -18,9 +21,6 @@ export const loadUserData = createAsyncThunk("auth/loadUserData", async () => {
   }
 
   const person = await response.json();
-  if (!user || user.expired) {
-    return null;
-  }
 
   // Update what we got from the OIDC provider with what we got from the API
   user.profile.nickname = person.nickname;


### PR DESCRIPTION
Closes #964

While reviewing the authentication flow, `loadUserData` in `frontend/src/features/auth.js` was fetching `/api/users/` using `user.access_token` before checking if the user was null or expired.

If `user` is null, accessing `user.access_token` throws a TypeError. If the token is expired, the fetch runs with a stale token causing a 401 response.

Fixed by moving the null/expired check before the fetch.

## Changes
- Only `frontend/src/features/auth.js` is changed