### PR TITLE
Add sticky sidebar with hidden overflow scroll on desktop

### DIFF
--- a/frontend/src/components/itempage.jsx
+++ b/frontend/src/components/itempage.jsx
@@ -8,6 +8,7 @@ import { formatTime, generateIdentity } from "../features/util.js";
 import Mistaken from "../routes/mistaken.jsx";
 import AccoItem from "./accoitem.jsx";
 import Grouping from "./grouping.jsx";
+import SideArea from "./sidearea.jsx";
 
 export default function ItemPage({ query, title, dataKey, buttons }) {
   const { data: list, isLoading, error } = query;
@@ -28,7 +29,7 @@ export default function ItemPage({ query, title, dataKey, buttons }) {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2">
             <Card.Title className="dataelem text-truncate">{title}</Card.Title>
@@ -49,7 +50,7 @@ export default function ItemPage({ query, title, dataKey, buttons }) {
             {name}
           </Button>
         ))}
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9 d-flex flex-column gap-2">
         {typelist &&
           Object.entries(typelist).map(

--- a/frontend/src/components/navigate.jsx
+++ b/frontend/src/components/navigate.jsx
@@ -38,7 +38,13 @@ export default function Navigate() {
   };
 
   return (
-    <Navbar bg={`${vibe}`} className="shadow-sm sticky-top p-0" style={{ background: vibe, "--vibe": vibe }}>
+    <Navbar
+      /* Publish navbar height as a CSS variable for the sticky sidebar positioning */
+      ref={(el) => el && document.documentElement.style.setProperty("--navbar-height", `${el.offsetHeight}px`)}
+      bg={`${vibe}`}
+      className="shadow-sm sticky-top p-0"
+      style={{ background: vibe, "--vibe": vibe }}
+    >
       <Container>
         <Navbar.Brand className="d-flex align-items-center flex-grow-1">
           <Link to="/">

--- a/frontend/src/components/sidearea.jsx
+++ b/frontend/src/components/sidearea.jsx
@@ -1,0 +1,3 @@
+export default function SideArea({ children }) {
+  return <div className="col-12 col-lg-3 d-flex flex-column gap-2 sidebar-scroll">{children}</div>;
+}

--- a/frontend/src/routes/accolade.jsx
+++ b/frontend/src/routes/accolade.jsx
@@ -5,6 +5,7 @@ import { Badge, Button, Card, ListGroup } from "react-bootstrap";
 import { useSelector } from "react-redux";
 import { Link, useParams, useSearchParams } from "react-router";
 
+import SideArea from "../components/sidearea.jsx";
 import VertItem from "../components/vertitem.jsx";
 import { useRetrieveAccoladeQuery, useRetrieveAvermentQuery } from "../features/call.js";
 import { useLoadingState } from "../features/hook.js";
@@ -114,7 +115,7 @@ export default function Accolade() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Img variant="top" src={relativeImageUrl(acco.image)} />
           <Card.Body className="p-2">
@@ -250,7 +251,7 @@ export default function Accolade() {
             </Button>
           </div>
         )}
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="ps-0 pe-0 pt-2 pb-0">

--- a/frontend/src/routes/addendum.jsx
+++ b/frontend/src/routes/addendum.jsx
@@ -3,6 +3,7 @@ import { Card } from "react-bootstrap";
 import Markdown from "react-markdown";
 import { useDispatch, useSelector } from "react-redux";
 
+import SideArea from "../components/sidearea.jsx";
 import { hideLoad, showLoad } from "../features/part.js";
 
 export default function Addendum() {
@@ -26,7 +27,7 @@ export default function Addendum() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2">
             <Card.Title className="dataelem text-truncate">Fedora Badges</Card.Title>
@@ -54,7 +55,7 @@ export default function Addendum() {
             </Card.Text>
           </Card.Body>
         </Card>
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="ps-0 pe-0 pt-2 pb-0">

--- a/frontend/src/routes/authlist.jsx
+++ b/frontend/src/routes/authlist.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Badge, Card, ListGroup } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 
+import SideArea from "../components/sidearea.jsx";
 import UserCard from "../components/usercard.jsx";
 import UserSide from "../components/userside.jsx";
 import VertItem from "../components/vertitem.jsx";
@@ -54,7 +55,7 @@ export default function AuthList() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <UserCard
           mail={profile.user.mail}
           name={profile.user.nickname}
@@ -64,7 +65,7 @@ export default function AuthList() {
           earn={profile.percent_earned}
         />
         <UserSide identity={authUser.nickname} authUser={authUser} />
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="ps-0 pe-0 pt-2 pb-0">

--- a/frontend/src/routes/campaign.jsx
+++ b/frontend/src/routes/campaign.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router";
 
 import BaseNote from "../components/basenote.jsx";
+import SideArea from "../components/sidearea.jsx";
 import UserCard from "../components/usercard.jsx";
 import UserSide from "../components/userside.jsx";
 import VertItem from "../components/vertitem.jsx";
@@ -80,7 +81,7 @@ export default function Campaign() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <UserCard
           mail={profile.user.mail}
           name={profile.user.nickname}
@@ -90,7 +91,7 @@ export default function Campaign() {
           earn={profile.percent_earned}
         />
         <UserSide identity={authUser.nickname} authUser={authUser} />
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="ps-0 pe-0 pt-2 pb-0">

--- a/frontend/src/routes/category.jsx
+++ b/frontend/src/routes/category.jsx
@@ -6,6 +6,7 @@ import { Link, useParams } from "react-router";
 
 import AccoItem from "../components/accoitem.jsx";
 import Grouping from "../components/grouping.jsx";
+import SideArea from "../components/sidearea.jsx";
 import { useRetrieveCategoryQuery } from "../features/call.js";
 import { useLoadingState } from "../features/hook.js";
 import { formatTime, generateIdentity } from "../features/util.js";
@@ -28,7 +29,7 @@ export default function Category() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2">
             <Card.Title className="dataelem text-truncate">Category</Card.Title>
@@ -46,7 +47,7 @@ export default function Category() {
           <Icon path={mdiViewGridPlus} size={0.875} className="me-1" />
           Complete collection
         </Button>
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9">
         <Grouping name={category} wide={list.length} head={true}>
           {list.map((item) => (

--- a/frontend/src/routes/contrast.jsx
+++ b/frontend/src/routes/contrast.jsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router";
 
 import AccoItem from "../components/accoitem.jsx";
 import Grouping from "../components/grouping.jsx";
+import SideArea from "../components/sidearea.jsx";
 import UserCard from "../components/usercard.jsx";
 import UserSide from "../components/userside.jsx";
 import VertItem from "../components/vertitem.jsx";
@@ -66,7 +67,7 @@ export default function Contrast() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <UserCard
           mail={user_b.avatar}
           name={user_b.nickname}
@@ -76,7 +77,7 @@ export default function Contrast() {
           earn={user_b.percent_earned}
         />
         <UserSide identity={id_b} authUser={authUser} />
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9 d-flex flex-column gap-2">
         <div className="row g-2">
           {stat.map(({ self, peer, selfUnique, peerUnique }) => (

--- a/frontend/src/routes/findpage.jsx
+++ b/frontend/src/routes/findpage.jsx
@@ -2,6 +2,7 @@ import { Badge, Card, ListGroup } from "react-bootstrap";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import SideArea from "../components/sidearea.jsx";
 import VertItem from "../components/vertitem.jsx";
 import { useRetrieveDiscoverQuery } from "../features/call.js";
 import { useLoadingState } from "../features/hook.js";
@@ -29,14 +30,14 @@ export default function FindPage() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2">
             <Card.Title className="dataelem text-truncate">Search result</Card.Title>
             <Card.Text className="small">For "{findtext}"</Card.Text>
           </Card.Body>
         </Card>
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9 d-flex flex-column gap-2">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="ps-0 pe-0 pt-2 pb-0">

--- a/frontend/src/routes/governor.jsx
+++ b/frontend/src/routes/governor.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router";
 
 import BaseNote from "../components/basenote.jsx";
 import HeadItem from "../components/headitem.jsx";
+import SideArea from "../components/sidearea.jsx";
 import AssertionCreationForm from "../crud/assertions/create.jsx";
 import AssertionUpdateForm from "../crud/assertions/delete.jsx";
 import AuthorizationCreationForm from "../crud/authorizations/create.jsx";
@@ -58,7 +59,7 @@ export default function Governor() {
   return (
     <>
       <div className="row g-2 mb-2">
-        <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+        <SideArea>
           <Card className="vibe-border" style={{ "--vibe": vibe }}>
             <Card.Body className="p-2">
               <Card.Title className="dataelem text-truncate">Governor</Card.Title>
@@ -95,7 +96,7 @@ export default function Governor() {
               Database
             </Button>
           )}
-        </div>
+        </SideArea>
         <div className="col-12 col-lg-9 d-flex flex-column gap-2">
           <HeadItem icon={mdiMedal} name="Assertions" vibe={vibe} />
           <AssertionCreationForm />

--- a/frontend/src/routes/homepage.jsx
+++ b/frontend/src/routes/homepage.jsx
@@ -13,6 +13,7 @@ import { Button, Card, ListGroup, OverlayTrigger, Tooltip } from "react-bootstra
 import { useSelector } from "react-redux";
 import { Link, useNavigate } from "react-router";
 
+import SideArea from "../components/sidearea.jsx";
 import VertItem from "../components/vertitem.jsx";
 import { useRetrieveAccoListQuery, useRetrieveGrantingQuery } from "../features/call.js";
 import { useLoadingState } from "../features/hook.js";
@@ -68,7 +69,7 @@ export default function Homepage() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2">
             <Card.Title className="dataelem text-truncate">Fedora Badges</Card.Title>
@@ -146,7 +147,7 @@ export default function Homepage() {
           <Icon path={mdiHeart} size={0.875} className="me-1" />
           Contribute now
         </Button>
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-5">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="ps-0 pe-0 pt-2 pb-0">

--- a/frontend/src/routes/identity.jsx
+++ b/frontend/src/routes/identity.jsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router";
 
 import AccoItem from "../components/accoitem.jsx";
 import Grouping from "../components/grouping.jsx";
+import SideArea from "../components/sidearea.jsx";
 import StarData from "../components/stardata.jsx";
 import UserCard from "../components/usercard.jsx";
 import UserSide from "../components/userside.jsx";
@@ -37,7 +38,7 @@ export default function Identity() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <UserCard
           mail={user.user.mail}
           name={user.user.nickname}
@@ -47,7 +48,7 @@ export default function Identity() {
           earn={user.percent_earned}
         />
         <UserSide identity={identity} authUser={authUser} />
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9 d-flex flex-column gap-2">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2 justify-content-between">

--- a/frontend/src/routes/rankings.jsx
+++ b/frontend/src/routes/rankings.jsx
@@ -4,6 +4,7 @@ import { Badge, Button, Card, Form, ListGroup } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation, useNavigate, useParams } from "react-router";
 
+import SideArea from "../components/sidearea.jsx";
 import VertItem from "../components/vertitem.jsx";
 import { useRetrieveRankingsQuery } from "../features/call.js";
 import { useLoadingState } from "../features/hook.js";
@@ -127,7 +128,7 @@ export default function Rankings() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2">
             <Card.Title className="dataelem text-truncate">Rankings</Card.Title>
@@ -245,7 +246,7 @@ export default function Rankings() {
             For {params.y}
           </Button>
         ) : null}
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="ps-0 pe-0 pt-2 pb-0">

--- a/frontend/src/routes/rarities.jsx
+++ b/frontend/src/routes/rarities.jsx
@@ -4,6 +4,7 @@ import { Link, useParams } from "react-router";
 
 import AccoItem from "../components/accoitem.jsx";
 import Grouping from "../components/grouping.jsx";
+import SideArea from "../components/sidearea.jsx";
 import { useRetrieveRaritiesQuery } from "../features/call.js";
 import { useLoadingState } from "../features/hook.js";
 import { formatTime, generateIdentity, obtainRarityText, rareColors, rarities } from "../features/util.js";
@@ -28,7 +29,7 @@ export default function Rarities() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <Card className="vibe-border" style={{ "--vibe": rareColors[rareunit.toUpperCase()] }}>
           <Card.Img variant="top" src={`/imgs/rare_${rareunit.toLowerCase()}.png`} />
           <Card.Body className="p-2">
@@ -59,7 +60,7 @@ export default function Rarities() {
               </span>
             </Button>
           ))}
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9">
         <Grouping name={`Tier ${rareunit}`} wide={page.length} head={true}>
           {page.map((item) => (

--- a/frontend/src/routes/userpast.jsx
+++ b/frontend/src/routes/userpast.jsx
@@ -2,6 +2,7 @@ import { Badge, Card, ListGroup } from "react-bootstrap";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import SideArea from "../components/sidearea.jsx";
 import TimeLine from "../components/timeline.jsx";
 import UserCard from "../components/usercard.jsx";
 import UserSide from "../components/userside.jsx";
@@ -36,7 +37,7 @@ export default function UserPast() {
 
   return (
     <div className="row g-2 mb-2">
-      <div className="col-12 col-lg-3 d-flex flex-column gap-2">
+      <SideArea>
         <UserCard
           mail={user.user.mail}
           name={user.user.nickname}
@@ -46,7 +47,7 @@ export default function UserPast() {
           earn={user.percent_earned}
         />
         <UserSide identity={identity} authUser={authUser} />
-      </div>
+      </SideArea>
       <div className="col-12 col-lg-9 d-flex flex-column gap-2">
         <Card className="vibe-border" style={{ "--vibe": vibe }}>
           <Card.Body className="p-2">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -312,6 +312,22 @@ a.vibe-border {
   }
 }
 
+/* 992px is Bootstrap's lg breakpoint */
+@media (min-width: 992px) {
+  .sidebar-scroll {
+    position: sticky;
+    top: calc(var(--navbar-height) + 0.5rem);
+    max-height: calc(100vh - var(--navbar-height) - 1rem);
+    overflow-y: auto;
+    align-self: start;
+    scrollbar-width: none;
+  }
+
+  .sidebar-scroll::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 .recharts-wrapper,
 .recharts-wrapper * {
   outline: none !important;


### PR DESCRIPTION
## Summary
- Apply `sticky-lg-top` and `align-self-lg-start` to left-column containers across all two-column pages so sidebar cards remain visible while scrolling
- Uses responsive classes so sticky behavior does not activate on mobile where the columns stack vertically
- Excluded the `badges` detail page where the sidebar content (badge image, description, tier, status, first/last awarded, pagination) exceeds viewport height

## Affected pages
- itempage (covers assembly, livelist, deadlist, recently)
- homepage, addendum, governor
- identity, userpast, contrast, campaign
- category, rarities, rankings, findpage

Fixes: #992 

## Some Examples
<img width="1917" height="1004" alt="image" src="https://github.com/user-attachments/assets/cf56f251-0f28-4074-8be1-832a183804f6" />
<img width="1917" height="1004" alt="image" src="https://github.com/user-attachments/assets/478056dd-8f2c-4202-b2c9-0ff2d498807b" />
<img width="1917" height="1004" alt="image" src="https://github.com/user-attachments/assets/9a3970dc-ea55-4568-9fca-c20862b0039c" />
<img width="1917" height="1004" alt="image" src="https://github.com/user-attachments/assets/6c686dcb-5f6a-44fb-9f3d-d56bba785e3c" />
<img width="1917" height="1004" alt="image" src="https://github.com/user-attachments/assets/1e6a5a16-8a8d-4160-ac79-41f2173fa844" />
<img width="1917" height="1004" alt="image" src="https://github.com/user-attachments/assets/80726621-2d49-451a-9bda-f10683125cd8" />

I've tested it on different screen sizes, but it may need further testing to ensure no edge cases with overflow.