### PR TITLE
Correct user icon color on light mode navbar

### DIFF
--- a/frontend/src/components/navigate.jsx
+++ b/frontend/src/components/navigate.jsx
@@ -137,7 +137,12 @@ export default function Navigate() {
                 </NavDropdown.Item>
               </NavDropdown>
             ) : (
-              <NavDropdown title={<Icon path={mdiAccountCircle} size={1} />} drop="down" align="end" className="p-0">
+              <NavDropdown
+                title={<Icon path={mdiAccountCircle} size={1} />}
+                drop="down"
+                align="end"
+                className="p-0 vibe-dropdown"
+              >
                 <NavDropdown.Item onClick={handleLogin} className="small d-flex align-items-center p-1">
                   <Icon className="me-1" size={0.75} path={mdiLogin} />
                   Sign In


### PR DESCRIPTION
Correct user icon color on light mode navbar

Before

<img width="855" height="58" alt="image" src="https://github.com/user-attachments/assets/99c41d71-a238-43fe-bbcc-f40d01029a24" />

After

<img width="855" height="58" alt="image" src="https://github.com/user-attachments/assets/38d340af-b709-46cf-958f-95ec970872c2" />
